### PR TITLE
chore: fix codespell findings and improve naming

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = Cargo.lock
+ignore-words-list = DoubleClick

--- a/src/chart/comparison.rs
+++ b/src/chart/comparison.rs
@@ -56,13 +56,13 @@ impl ComparisonChart {
         let mut series = Vec::with_capacity(tickers.len());
         let mut series_index = FxHashMap::default();
         for (i, t) in tickers.iter().enumerate() {
-            let ser = SerTicker::from_parts(t.ticker);
+            let ser_ticker = SerTicker::from_parts(t.ticker);
 
             let color = color_map
-                .get(&ser)
+                .get(&ser_ticker)
                 .copied()
                 .unwrap_or_else(|| default_color_for(t));
-            let name = name_map.get(&ser).cloned();
+            let name = name_map.get(&ser_ticker).cloned();
 
             series.push(Series::new(*t, color, name));
 
@@ -444,8 +444,8 @@ impl ComparisonChart {
     }
 
     fn color_for_or_default(&self, ticker_info: &TickerInfo) -> iced::Color {
-        let ser = SerTicker::from_parts(ticker_info.ticker);
-        if let Some((_, c)) = self.config.colors.iter().find(|(s, _)| s == &ser) {
+        let ser_ticker = SerTicker::from_parts(ticker_info.ticker);
+        if let Some((_, c)) = self.config.colors.iter().find(|(s, _)| s == &ser_ticker) {
             *c
         } else {
             default_color_for(ticker_info)
@@ -476,11 +476,16 @@ impl ComparisonChart {
     }
 
     fn upsert_config_color(&mut self, ticker_info: TickerInfo, color: iced::Color) {
-        let ser = SerTicker::from_parts(ticker_info.ticker);
-        if let Some((_, c)) = self.config.colors.iter_mut().find(|(t, _)| *t == ser) {
+        let ser_ticker = SerTicker::from_parts(ticker_info.ticker);
+        if let Some((_, c)) = self
+            .config
+            .colors
+            .iter_mut()
+            .find(|(t, _)| *t == ser_ticker)
+        {
             *c = color;
         } else {
-            self.config.colors.push((ser, color));
+            self.config.colors.push((ser_ticker, color));
         }
     }
 


### PR DESCRIPTION
chore: fix codespell findings and improve naming (fmt clean)

Make the repository pass `codespell` cleanly without touching generated files or
renaming stable identifiers, and keep everything `rustfmt`-compliant.

Changes:
- [src/chart/comparison.rs](cci:7://file:///home/rezky/Desktop/flowsurface/src/chart/comparison.rs:0:0-0:0)
  - Rename local variable `ser` -> `ser_ticker` for clarity and to avoid
    codespell false positives.
  - Adjust formatting to match `rustfmt` output (so `cargo fmt -- --check` passes).

- [.codespellrc](cci:7://file:///home/rezky/Desktop/flowsurface/.codespellrc:0:0-0:0)
  - Skip [Cargo.lock](cci:7://file:///home/rezky/Desktop/flowsurface/Cargo.lock:0:0-0:0) (generated file; contains `inout` crate dependency name)
  - Ignore `DoubleClick` (intentional Rust identifier; renaming would be a larger refactor)

Rationale:
- [Cargo.lock](cci:7://file:///home/rezky/Desktop/flowsurface/Cargo.lock:0:0-0:0) should not be edited manually; dependency names like `inout` are
  not spelling mistakes.
- `DoubleClick` / `XAxisDoubleClick` are identifiers/events used across the code;
  ignoring them avoids an unnecessary API/behavior change.

Checks:
- `codespell` (pass)
- `cargo fmt --all -- --check` (pass)

Files changed:
- src/chart/comparison.rs
- .codespellrc

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: flowsurface
Branch: main
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: 21ad458957e30405af5b1b09120a66ee177995c55fb38451c46c2d1183479087 PrevHash: 2a9580b2eeab3b12bdfadedbe1833fa492ff24f90784056235ea43b62f52aff1 PatchHash: 3623d0cb28da78b2cdfed48bddc8db221dd1220a0a8288e2799718a6d7149afa

FilesChanged: 2
Lines: +16 / -8

Timestamp: 2025-12-27T14:00:55Z
Signature1: b8d98f388af60f7e6a773fd6e377c7c3ed017621cd62572f8569a0f9d67eb408
Signature2: 3ea621961697bb77e9b6f7915cbf764fa882b1b14b7c65e84d6af9285792ac57