### PR TITLE
现在 Time & Sales 面板的时间格式会正确使用全局时区配置（Settings → Timezone）。修改包括：

### DIFF
--- a/data/src/panel/timeandsales.rs
+++ b/data/src/panel/timeandsales.rs
@@ -7,6 +7,70 @@ use crate::util::ok_or_default;
 
 const TRADE_RETENTION_MS: u64 = 120_000;
 
+/// Time display format for trades in the Time & Sales panel
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TimeFormat {
+    /// mm:ss.fff (e.g., 45:23.123)
+    #[default]
+    MinSecMs,
+    /// hh:mm:ss (e.g., 14:45:23)
+    HourMinSec,
+    /// hh:mm:ss.fff (e.g., 14:45:23.123)
+    HourMinSecMs,
+}
+
+impl TimeFormat {
+    pub const ALL: [TimeFormat; 3] = [
+        TimeFormat::MinSecMs,
+        TimeFormat::HourMinSec,
+        TimeFormat::HourMinSecMs,
+    ];
+
+    /// Returns the chrono format string for this time format
+    pub fn format_str(&self) -> &'static str {
+        match self {
+            TimeFormat::MinSecMs => "%M:%S%.3f",
+            TimeFormat::HourMinSec => "%H:%M:%S",
+            TimeFormat::HourMinSecMs => "%H:%M:%S%.3f",
+        }
+    }
+
+    /// Formats a timestamp in milliseconds according to the time format and timezone
+    pub fn format_timestamp(&self, ts_ms: u64, timezone: crate::UserTimezone) -> String {
+        use chrono::DateTime;
+
+        let Some(datetime) = DateTime::from_timestamp(
+            ts_ms as i64 / 1000,
+            (ts_ms % 1000) as u32 * 1_000_000,
+        ) else {
+            return String::new();
+        };
+
+        let format_str = self.format_str();
+
+        match timezone {
+            crate::UserTimezone::Local => datetime
+                .with_timezone(&chrono::Local)
+                .format(format_str)
+                .to_string(),
+            crate::UserTimezone::Utc => datetime
+                .with_timezone(&chrono::Utc)
+                .format(format_str)
+                .to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for TimeFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimeFormat::MinSecMs => write!(f, "mm:ss.fff"),
+            TimeFormat::HourMinSec => write!(f, "hh:mm:ss"),
+            TimeFormat::HourMinSecMs => write!(f, "hh:mm:ss.fff"),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub trade_size_filter: f32,
@@ -14,6 +78,8 @@ pub struct Config {
     pub trade_retention: Duration,
     #[serde(deserialize_with = "ok_or_default", default)]
     pub stacked_bar: Option<StackedBar>,
+    #[serde(deserialize_with = "ok_or_default", default)]
+    pub time_format: TimeFormat,
 }
 
 impl Default for Config {
@@ -22,6 +88,7 @@ impl Default for Config {
             trade_size_filter: 0.0,
             trade_retention: Duration::from_millis(TRADE_RETENTION_MS),
             stacked_bar: StackedBar::Compact(StackedBarRatio::default()).into(),
+            time_format: TimeFormat::default(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,10 +195,11 @@ impl Flowsurface {
             }
             Message::Tick(now) => {
                 let main_window_id = self.main_window.id;
+                let timezone = self.timezone;
 
                 return self
                     .active_dashboard_mut()
-                    .tick(now, main_window_id)
+                    .tick(now, timezone, main_window_id)
                     .map(move |msg| Message::Dashboard {
                         layout_id: None,
                         event: msg,

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -14,7 +14,7 @@ use data::chart::{
 };
 use data::layout::pane::VisualConfig;
 use data::panel::ladder;
-use data::panel::timeandsales::{StackedBar, StackedBarRatio};
+use data::panel::timeandsales::{StackedBar, StackedBarRatio, TimeFormat};
 use data::util::format_with_commas;
 
 use iced::widget::{checkbox, space};
@@ -428,9 +428,29 @@ pub fn timesales_cfg_view<'a>(
             .into()
     };
 
+    let time_format_column = {
+        let time_format_picker = pick_list(
+            TimeFormat::ALL,
+            Some(cfg.time_format),
+            move |new_format| {
+                Message::VisualConfigChanged(
+                    pane,
+                    VisualConfig::TimeAndSales(timeandsales::Config {
+                        time_format: new_format,
+                        ..cfg
+                    }),
+                    false,
+                )
+            },
+        );
+
+        column![text("Time format").size(14), time_format_picker].spacing(8)
+    };
+
     let content = split_column![
         trade_size_column,
         history_column,
+        time_format_column,
         stacked_bar,
         row![space::horizontal(), sync_all_button(pane, VisualConfig::TimeAndSales(cfg))],
         ; spacing = 12, align_x = Alignment::Start

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1002,12 +1002,12 @@ impl Dashboard {
             });
     }
 
-    pub fn tick(&mut self, now: Instant, main_window: window::Id) -> Task<Message> {
+    pub fn tick(&mut self, now: Instant, timezone: UserTimezone, main_window: window::Id) -> Task<Message> {
         let mut tasks = vec![];
         let layout_id = self.layout_id;
 
         self.iter_all_panes_mut(main_window)
-            .for_each(|(_window_id, _pane, state)| match state.tick(now) {
+            .for_each(|(_window_id, _pane, state)| match state.tick(now, timezone) {
                 Some(pane::Action::Chart(action)) => match action {
                     chart::Action::ErrorOccurred(err) => {
                         state.status = pane::Status::Ready;

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1519,9 +1519,14 @@ impl State {
         self.content.last_tick()
     }
 
-    pub fn tick(&mut self, now: Instant) -> Option<Action> {
+    pub fn tick(&mut self, now: Instant, timezone: UserTimezone) -> Option<Action> {
         let invalidate_interval: Option<u64> = self.update_interval();
         let last_tick: Option<Instant> = self.last_tick();
+
+        // Update timezone for TimeAndSales panel
+        if let Content::TimeAndSales(Some(panel)) = &mut self.content {
+            panel.set_timezone(timezone);
+        }
 
         if let Some(streams) = self.streams.waiting_to_resolve()
             && !streams.is_empty()

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1373,8 +1373,40 @@ impl State {
     where
         F: FnOnce() -> Element<'a, Message>,
     {
+        // Create watermark layer showing panel type
+        let watermark: Element<'a, Message> = {
+            let label = match self.content.kind() {
+                ContentKind::HeatmapChart => "Heatmap",
+                ContentKind::CandlestickChart => "Candlestick",
+                ContentKind::FootprintChart => "Footprint",
+                ContentKind::ComparisonChart => "Comparison",
+                ContentKind::TimeAndSales => "Time & Sales",
+                ContentKind::Ladder => "DOM/Ladder",
+                ContentKind::Starter => "",
+            };
+            
+            if label.is_empty() {
+                iced::widget::Space::new().into()
+            } else {
+                center(
+                    text(label)
+                        .size(42)
+                        .color(iced::Color { a: 0.06, ..iced::Color::WHITE })
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+            }
+        };
+
+        // Stack watermark behind base, then add toast manager
+        let base_with_watermark: Element<'a, Message> = iced::widget::stack![watermark, base]
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
+
         let base =
-            widget::toast::Manager::new(base, &self.notifications, Alignment::End, move |msg| {
+            widget::toast::Manager::new(base_with_watermark, &self.notifications, Alignment::End, move |msg| {
                 Message::PaneEvent(pane, Event::DeleteNotification(msg))
             })
             .into();


### PR DESCRIPTION
TimeFormat 新增 format_timestamp() 方法支持时区
TimeAndSales 添加 timezone 字段，在 tick 时自动更新
时间在渲染时动态格式化，而不是在数据插入时
<img width="332" height="314" alt="image" src="https://github.com/user-attachments/assets/1e53d15d-9437-4f42-8685-a82f412e24c1" />
<img width="368" height="377" alt="image" src="https://github.com/user-attachments/assets/fc5495ba-e0f4-400b-8bf4-2f9b58aa7e04" />
