### PR TITLE
feat: add sync symbol to all panels button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,18 @@ impl Flowsurface {
                             event: msg,
                         });
                     }
+                    Some(dashboard::sidebar::Action::SyncToAllPanes(ticker_info)) => {
+                        let main_window_id = self.main_window.id;
+
+                        let task = self
+                            .active_dashboard_mut()
+                            .switch_all_panes_to_ticker(main_window_id, ticker_info);
+
+                        return task.map(move |msg| Message::Dashboard {
+                            layout_id: None,
+                            event: msg,
+                        });
+                    }
                     Some(dashboard::sidebar::Action::ErrorOccurred(err)) => {
                         self.notifications.push(Toast::error(err.to_string()));
                     }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -31,6 +31,7 @@ pub enum Action {
         exchange::TickerInfo,
         Option<data::layout::pane::ContentKind>,
     ),
+    SyncToAllPanes(exchange::TickerInfo),
     ErrorOccurred(data::InternalError),
 }
 
@@ -69,6 +70,9 @@ impl Sidebar {
                             Task::none(),
                             Some(Action::TickerSelected(ticker_info, content)),
                         );
+                    }
+                    Some(tickers_table::Action::SyncToAllPanes(ticker_info)) => {
+                        return (Task::none(), Some(Action::SyncToAllPanes(ticker_info)));
                     }
                     Some(tickers_table::Action::Fetch(task)) => {
                         return (task.map(Message::TickersTable), None);


### PR DESCRIPTION
Add a "Sync All" button in the expanded ticker card that applies the selected symbol to all active panels at once, preserving each panel's chart type (Heatmap, Footprint, Candlestick, etc.).

Changes:
- Add SyncToAllPanes action in tickers_table and sidebar
- Add switch_all_panes_to_ticker() method in dashboard
- Add "Sync All" button in expanded ticker card header