### PR TITLE
add cumulative delta indicator

### DIFF
--- a/data/src/chart/indicator.rs
+++ b/data/src/chart/indicator.rs
@@ -13,6 +13,7 @@ pub trait Indicator: PartialEq + Display + 'static {
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize, Eq, Enum)]
 pub enum KlineIndicator {
     Volume,
+    CumulativeDelta,
     OpenInterest,
 }
 
@@ -29,15 +30,20 @@ impl KlineIndicator {
     // Indicator togglers on UI menus depend on these arrays.
     // Every variant needs to be in either SPOT, PERPS or both.
     /// Indicators that can be used with spot market tickers
-    const FOR_SPOT: [KlineIndicator; 1] = [KlineIndicator::Volume];
+    const FOR_SPOT: [KlineIndicator; 2] = [KlineIndicator::Volume, KlineIndicator::CumulativeDelta];
     /// Indicators that can be used with perpetual swap market tickers
-    const FOR_PERPS: [KlineIndicator; 2] = [KlineIndicator::Volume, KlineIndicator::OpenInterest];
+    const FOR_PERPS: [KlineIndicator; 3] = [
+        KlineIndicator::Volume,
+        KlineIndicator::CumulativeDelta,
+        KlineIndicator::OpenInterest,
+    ];
 }
 
 impl Display for KlineIndicator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             KlineIndicator::Volume => write!(f, "Volume"),
+            KlineIndicator::CumulativeDelta => write!(f, "CVD"),
             KlineIndicator::OpenInterest => write!(f, "Open Interest"),
         }
     }

--- a/src/chart/indicator/kline.rs
+++ b/src/chart/indicator/kline.rs
@@ -87,7 +87,7 @@ pub trait KlineIndicatorImpl {
     /// Rebuild data using kline(OHLCV) source
     fn rebuild_from_source(&mut self, _source: &PlotData<KlineDataPoint>) {}
 
-    fn on_insert_klines(&mut self, _klines: &[Kline]) {}
+    fn on_insert_klines(&mut self, _klines: &[Kline], _source: &PlotData<KlineDataPoint>) {}
 
     fn on_insert_trades(
         &mut self,

--- a/src/chart/indicator/kline.rs
+++ b/src/chart/indicator/kline.rs
@@ -6,6 +6,7 @@ use data::chart::indicator::KlineIndicator;
 use data::chart::kline::KlineDataPoint;
 use exchange::{Kline, Timeframe, Trade};
 
+pub mod cumulative_delta;
 pub mod open_interest;
 pub mod volume;
 
@@ -60,6 +61,9 @@ pub struct FetchCtx<'a> {
 pub fn make_empty(which: KlineIndicator) -> Box<dyn KlineIndicatorImpl> {
     match which {
         KlineIndicator::Volume => Box::new(super::kline::volume::VolumeIndicator::new()),
+        KlineIndicator::CumulativeDelta => {
+            Box::new(super::kline::cumulative_delta::CumulativeDeltaIndicator::new())
+        }
         KlineIndicator::OpenInterest => {
             Box::new(super::kline::open_interest::OpenInterestIndicator::new())
         }

--- a/src/chart/indicator/kline/cumulative_delta.rs
+++ b/src/chart/indicator/kline/cumulative_delta.rs
@@ -2,16 +2,21 @@ use crate::chart::{
     Caches, Message, ViewState,
     indicator::{
         indicator_row,
-        kline::KlineIndicatorImpl,
+        kline::{AvailabilityCause, IndicatorAvailability, KlineIndicatorImpl},
         plot::{PlotTooltip, line::LinePlot},
     },
 };
 
-use data::chart::{PlotData, kline::KlineDataPoint};
+use data::chart::{
+    PlotData,
+    kline::{KlineDataPoint, KlineTrades},
+};
 use data::util::format_with_commas;
 use exchange::{Kline, Trade, Volume};
 
-use std::collections::BTreeMap;
+use iced::widget::{center, text};
+
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::RangeInclusive;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -28,6 +33,7 @@ pub struct CumulativeDeltaIndicator {
     /// rebuild the cumulative line without needing the full chart source.
     delta: BTreeMap<u64, f32>,
     data: BTreeMap<u64, CumulativeDeltaPoint>,
+    availability: IndicatorAvailability,
 }
 
 impl CumulativeDeltaIndicator {
@@ -36,6 +42,7 @@ impl CumulativeDeltaIndicator {
             cache: Caches::default(),
             delta: BTreeMap::new(),
             data: BTreeMap::new(),
+            availability: IndicatorAvailability::Unknown,
         }
     }
 
@@ -44,6 +51,10 @@ impl CumulativeDeltaIndicator {
         main_chart: &'a ViewState,
         visible_range: RangeInclusive<u64>,
     ) -> iced::Element<'a, Message> {
+        if let Some(message) = self.unavailable_message(main_chart, "CVD") {
+            return center(text(message)).into();
+        }
+
         let tooltip = |point: &CumulativeDeltaPoint, _next: Option<&CumulativeDeltaPoint>| {
             let cvd = format!("CVD: {}", format_with_commas(point.cumulative));
             let sign = if point.delta >= 0.0 { "+" } else { "" };
@@ -67,6 +78,10 @@ impl CumulativeDeltaIndicator {
         Self::volume_delta(kline.volume)
     }
 
+    fn has_directional_volume(volume: Volume) -> bool {
+        volume.buy_sell().is_some()
+    }
+
     fn volume_delta(volume: Volume) -> f32 {
         volume
             .buy_sell()
@@ -74,19 +89,42 @@ impl CumulativeDeltaIndicator {
             .unwrap_or(0.0)
     }
 
-    fn datapoint_delta(dp: &KlineDataPoint) -> f32 {
-        let footprint_delta: f32 = dp
-            .footprint
+    fn footprint_delta(footprint: &KlineTrades) -> f32 {
+        footprint
             .trades
             .values()
             .map(|group| f32::from(group.delta_qty()))
-            .sum();
+            .sum()
+    }
 
-        if dp.footprint.trades.is_empty() {
-            Self::volume_delta(dp.kline.volume)
+    fn delta_from_parts(footprint: &KlineTrades, volume: Volume) -> f32 {
+        if footprint.trades.is_empty() {
+            Self::volume_delta(volume)
         } else {
-            footprint_delta
+            Self::footprint_delta(footprint)
         }
+    }
+
+    fn is_directional_parts(footprint: &KlineTrades, volume: Volume) -> bool {
+        !footprint.trades.is_empty() || Self::has_directional_volume(volume)
+    }
+
+    fn datapoint_delta(dp: &KlineDataPoint) -> f32 {
+        Self::delta_from_parts(&dp.footprint, dp.kline.volume)
+    }
+
+    fn is_datapoint_directional(dp: &KlineDataPoint) -> bool {
+        Self::is_directional_parts(&dp.footprint, dp.kline.volume)
+    }
+
+    fn set_availability(&mut self, has_points: bool, has_directional: bool) {
+        self.availability = if !has_points {
+            IndicatorAvailability::Unknown
+        } else if has_directional {
+            IndicatorAvailability::Available
+        } else {
+            IndicatorAvailability::Unavailable(AvailabilityCause::TradeData)
+        };
     }
 
     fn rebuild_cumulative(&mut self) {
@@ -95,7 +133,8 @@ impl CumulativeDeltaIndicator {
         let mut cumulative = 0.0;
         for (&x, &delta) in &self.delta {
             cumulative += delta;
-            self.data.insert(x, CumulativeDeltaPoint { delta, cumulative });
+            self.data
+                .insert(x, CumulativeDeltaPoint { delta, cumulative });
         }
 
         self.clear_all_caches();
@@ -124,41 +163,140 @@ impl KlineIndicatorImpl for CumulativeDeltaIndicator {
         self.indicator_elem(chart, visible_range)
     }
 
+    fn availability(&self, _chart: &ViewState) -> IndicatorAvailability {
+        self.availability.clone()
+    }
+
     fn rebuild_from_source(&mut self, source: &PlotData<KlineDataPoint>) {
-        let deltas = match source {
-            PlotData::TimeBased(timeseries) => timeseries
-                .datapoints
-                .iter()
-                .map(|(&time, dp)| (time, Self::datapoint_delta(dp)))
-                .collect(),
-            PlotData::TickBased(tickseries) => tickseries
-                .datapoints
-                .iter()
-                .enumerate()
-                .map(|(idx, dp)| {
-                    let delta = Self::volume_delta(dp.kline.volume);
-                    (idx as u64, delta)
-                })
-                .collect(),
+        let (deltas, has_points, has_directional) = match source {
+            PlotData::TimeBased(timeseries) => {
+                let has_points = !timeseries.datapoints.is_empty();
+                let has_directional = timeseries
+                    .datapoints
+                    .values()
+                    .any(Self::is_datapoint_directional);
+
+                let deltas = timeseries
+                    .datapoints
+                    .iter()
+                    .map(|(&time, dp)| (time, Self::datapoint_delta(dp)))
+                    .collect();
+
+                (deltas, has_points, has_directional)
+            }
+            PlotData::TickBased(tickseries) => {
+                let has_points = !tickseries.datapoints.is_empty();
+                let has_directional = tickseries
+                    .datapoints
+                    .iter()
+                    .any(|dp| Self::is_directional_parts(&dp.footprint, dp.kline.volume));
+
+                let deltas = tickseries
+                    .datapoints
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, dp)| {
+                        (
+                            idx as u64,
+                            Self::delta_from_parts(&dp.footprint, dp.kline.volume),
+                        )
+                    })
+                    .collect();
+
+                (deltas, has_points, has_directional)
+            }
         };
+
+        self.set_availability(has_points, has_directional);
 
         self.rebuild_from_deltas(deltas);
     }
 
-    fn on_insert_klines(&mut self, klines: &[Kline]) {
+    fn on_insert_klines(&mut self, klines: &[Kline], source: &PlotData<KlineDataPoint>) {
+        let mut has_directional = false;
+
         for kline in klines {
-            self.delta.insert(kline.time, Self::kline_delta(kline));
+            let (delta, directional) = match source {
+                PlotData::TimeBased(timeseries) => {
+                    if let Some(dp) = timeseries.datapoints.get(&kline.time) {
+                        (
+                            Self::datapoint_delta(dp),
+                            Self::is_datapoint_directional(dp),
+                        )
+                    } else {
+                        (
+                            Self::kline_delta(kline),
+                            Self::has_directional_volume(kline.volume),
+                        )
+                    }
+                }
+                PlotData::TickBased(_) => (
+                    Self::kline_delta(kline),
+                    Self::has_directional_volume(kline.volume),
+                ),
+            };
+
+            self.delta.insert(kline.time, delta);
+            has_directional |= directional;
         }
+
+        if has_directional {
+            self.availability = IndicatorAvailability::Available;
+        }
+
+        if self.availability == IndicatorAvailability::Unknown && !self.delta.is_empty() {
+            self.availability = IndicatorAvailability::Unavailable(AvailabilityCause::TradeData);
+        }
+
         self.rebuild_cumulative();
     }
 
     fn on_insert_trades(
         &mut self,
-        _trades: &[Trade],
-        _old_dp_len: usize,
+        trades: &[Trade],
+        old_dp_len: usize,
         source: &PlotData<KlineDataPoint>,
     ) {
-        self.rebuild_from_source(source);
+        let mut touched = false;
+
+        match source {
+            PlotData::TimeBased(timeseries) => {
+                if trades.is_empty() {
+                    return;
+                }
+
+                let aggr_time = timeseries.interval.to_milliseconds();
+                let mut touched_times = BTreeSet::new();
+
+                for trade in trades {
+                    let rounded_time = (trade.time / aggr_time) * aggr_time;
+                    touched_times.insert(rounded_time);
+                }
+
+                for time in touched_times {
+                    if let Some(dp) = timeseries.datapoints.get(&time) {
+                        self.delta.insert(time, Self::datapoint_delta(dp));
+                        touched = true;
+                    }
+                }
+            }
+            PlotData::TickBased(tickseries) => {
+                let start_idx = old_dp_len.saturating_sub(1);
+
+                for (idx, dp) in tickseries.datapoints.iter().enumerate().skip(start_idx) {
+                    self.delta.insert(
+                        idx as u64,
+                        Self::delta_from_parts(&dp.footprint, dp.kline.volume),
+                    );
+                    touched = true;
+                }
+            }
+        }
+
+        if touched {
+            self.availability = IndicatorAvailability::Available;
+            self.rebuild_cumulative();
+        }
     }
 
     fn on_ticksize_change(&mut self, source: &PlotData<KlineDataPoint>) {

--- a/src/chart/indicator/kline/cumulative_delta.rs
+++ b/src/chart/indicator/kline/cumulative_delta.rs
@@ -1,0 +1,171 @@
+use crate::chart::{
+    Caches, Message, ViewState,
+    indicator::{
+        indicator_row,
+        kline::KlineIndicatorImpl,
+        plot::{PlotTooltip, line::LinePlot},
+    },
+};
+
+use data::chart::{PlotData, kline::KlineDataPoint};
+use data::util::format_with_commas;
+use exchange::{Kline, Trade, Volume};
+
+use std::collections::BTreeMap;
+use std::ops::RangeInclusive;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CumulativeDeltaPoint {
+    /// Buy volume - sell volume for this candle / tick bucket.
+    pub delta: f32,
+    /// Running sum of delta from the oldest loaded datapoint to this datapoint.
+    pub cumulative: f32,
+}
+
+pub struct CumulativeDeltaIndicator {
+    cache: Caches,
+    /// Per-bucket delta. Stored separately so inserting/replacing older klines can
+    /// rebuild the cumulative line without needing the full chart source.
+    delta: BTreeMap<u64, f32>,
+    data: BTreeMap<u64, CumulativeDeltaPoint>,
+}
+
+impl CumulativeDeltaIndicator {
+    pub fn new() -> Self {
+        Self {
+            cache: Caches::default(),
+            delta: BTreeMap::new(),
+            data: BTreeMap::new(),
+        }
+    }
+
+    fn indicator_elem<'a>(
+        &'a self,
+        main_chart: &'a ViewState,
+        visible_range: RangeInclusive<u64>,
+    ) -> iced::Element<'a, Message> {
+        let tooltip = |point: &CumulativeDeltaPoint, _next: Option<&CumulativeDeltaPoint>| {
+            let cvd = format!("CVD: {}", format_with_commas(point.cumulative));
+            let sign = if point.delta >= 0.0 { "+" } else { "" };
+            let delta = format!("Delta: {sign}{}", format_with_commas(point.delta));
+            PlotTooltip::new(format!("{cvd}\n{delta}"))
+        };
+
+        let value_fn = |point: &CumulativeDeltaPoint| point.cumulative;
+
+        let plot = LinePlot::new(value_fn)
+            .stroke_width(1.0)
+            .show_points(true)
+            .point_radius_factor(0.2)
+            .padding(0.08)
+            .with_tooltip(tooltip);
+
+        indicator_row(main_chart, &self.cache, plot, &self.data, visible_range)
+    }
+
+    fn kline_delta(kline: &Kline) -> f32 {
+        Self::volume_delta(kline.volume)
+    }
+
+    fn volume_delta(volume: Volume) -> f32 {
+        volume
+            .buy_sell()
+            .map(|(buy, sell)| f32::from(buy) - f32::from(sell))
+            .unwrap_or(0.0)
+    }
+
+    fn datapoint_delta(dp: &KlineDataPoint) -> f32 {
+        let footprint_delta: f32 = dp
+            .footprint
+            .trades
+            .values()
+            .map(|group| f32::from(group.delta_qty()))
+            .sum();
+
+        if dp.footprint.trades.is_empty() {
+            Self::volume_delta(dp.kline.volume)
+        } else {
+            footprint_delta
+        }
+    }
+
+    fn rebuild_cumulative(&mut self) {
+        self.data.clear();
+
+        let mut cumulative = 0.0;
+        for (&x, &delta) in &self.delta {
+            cumulative += delta;
+            self.data.insert(x, CumulativeDeltaPoint { delta, cumulative });
+        }
+
+        self.clear_all_caches();
+    }
+
+    fn rebuild_from_deltas(&mut self, deltas: BTreeMap<u64, f32>) {
+        self.delta = deltas;
+        self.rebuild_cumulative();
+    }
+}
+
+impl KlineIndicatorImpl for CumulativeDeltaIndicator {
+    fn clear_all_caches(&mut self) {
+        self.cache.clear_all();
+    }
+
+    fn clear_crosshair_caches(&mut self) {
+        self.cache.clear_crosshair();
+    }
+
+    fn element<'a>(
+        &'a self,
+        chart: &'a ViewState,
+        visible_range: RangeInclusive<u64>,
+    ) -> iced::Element<'a, Message> {
+        self.indicator_elem(chart, visible_range)
+    }
+
+    fn rebuild_from_source(&mut self, source: &PlotData<KlineDataPoint>) {
+        let deltas = match source {
+            PlotData::TimeBased(timeseries) => timeseries
+                .datapoints
+                .iter()
+                .map(|(&time, dp)| (time, Self::datapoint_delta(dp)))
+                .collect(),
+            PlotData::TickBased(tickseries) => tickseries
+                .datapoints
+                .iter()
+                .enumerate()
+                .map(|(idx, dp)| {
+                    let delta = Self::volume_delta(dp.kline.volume);
+                    (idx as u64, delta)
+                })
+                .collect(),
+        };
+
+        self.rebuild_from_deltas(deltas);
+    }
+
+    fn on_insert_klines(&mut self, klines: &[Kline]) {
+        for kline in klines {
+            self.delta.insert(kline.time, Self::kline_delta(kline));
+        }
+        self.rebuild_cumulative();
+    }
+
+    fn on_insert_trades(
+        &mut self,
+        _trades: &[Trade],
+        _old_dp_len: usize,
+        source: &PlotData<KlineDataPoint>,
+    ) {
+        self.rebuild_from_source(source);
+    }
+
+    fn on_ticksize_change(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.rebuild_from_source(source);
+    }
+
+    fn on_basis_change(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.rebuild_from_source(source);
+    }
+}

--- a/src/chart/indicator/kline/open_interest.rs
+++ b/src/chart/indicator/kline/open_interest.rs
@@ -160,7 +160,7 @@ impl KlineIndicatorImpl for OpenInterestIndicator {
         self.clear_all_caches();
     }
 
-    fn on_insert_klines(&mut self, _klines: &[Kline]) {}
+    fn on_insert_klines(&mut self, _klines: &[Kline], _source: &PlotData<KlineDataPoint>) {}
 
     fn on_insert_trades(
         &mut self,

--- a/src/chart/indicator/kline/volume.rs
+++ b/src/chart/indicator/kline/volume.rs
@@ -97,7 +97,7 @@ impl KlineIndicatorImpl for VolumeIndicator {
         self.clear_all_caches();
     }
 
-    fn on_insert_klines(&mut self, klines: &[Kline]) {
+    fn on_insert_klines(&mut self, klines: &[Kline], _source: &PlotData<KlineDataPoint>) {
         for kline in klines {
             self.data.insert(kline.time, kline.volume);
         }

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -601,6 +601,13 @@ impl KlineChart {
             }
             PlotData::TimeBased(ref mut timeseries) => {
                 timeseries.insert_trades_existing_buckets(buffer);
+
+                self.indicators
+                    .values_mut()
+                    .filter_map(Option::as_mut)
+                    .for_each(|indi| indi.on_insert_trades(buffer, 0, &self.data_source));
+
+                self.invalidate(None);
             }
         }
     }
@@ -615,11 +622,18 @@ impl KlineChart {
             }
         }
 
-        self.raw_trades.extend(raw_trades);
+        self.raw_trades.extend_from_slice(&raw_trades);
+
+        self.indicators
+            .values_mut()
+            .filter_map(Option::as_mut)
+            .for_each(|indi| indi.on_insert_trades(&raw_trades, 0, &self.data_source));
 
         if is_batches_done {
             self.fetching_trades = (false, None);
         }
+
+        self.invalidate(None);
     }
 
     pub fn insert_hist_klines(&mut self, req_id: uuid::Uuid, klines_raw: &[Kline]) {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -319,7 +319,7 @@ impl KlineChart {
                 self.indicators
                     .values_mut()
                     .filter_map(Option::as_mut)
-                    .for_each(|indi| indi.on_insert_klines(&[*kline]));
+                    .for_each(|indi| indi.on_insert_klines(&[*kline], &self.data_source));
 
                 let chart = self.mut_state();
 
@@ -645,7 +645,7 @@ impl KlineChart {
                 self.indicators
                     .values_mut()
                     .filter_map(Option::as_mut)
-                    .for_each(|indi| indi.on_insert_klines(klines_raw));
+                    .for_each(|indi| indi.on_insert_klines(klines_raw, &self.data_source));
 
                 if klines_raw.is_empty() {
                     self.request_handler


### PR DESCRIPTION
## Summary

Adds a cumulative delta (CVD) kline indicator.

The indicator calculates per-bucket buy/sell delta and plots the running cumulative value as a line chart. It is available for both spot and perpetual markets.

## Changes

- adds `CumulativeDelta` to the kline indicator list
- computes delta from footprint trade groups when available
- falls back to kline buy/sell volume when footprint data is unavailable
- rebuilds the CVD series when trades are inserted
- refreshes the indicator on tick size and chart basis changes

## Testing

- `cargo check`