### PR TITLE
feat: display volume and delta summary text below footprint candles

### DIFF
--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1600,6 +1600,72 @@ fn draw_clusters(
             );
         }
     }
+
+    if show_text {
+        let mut total_buy = 0.0;
+        let mut total_sell = 0.0;
+        let mut total_delta = 0.0;
+
+        for group in footprint.trades.values() {
+            total_buy += f32::from(group.buy_qty);
+            total_sell += f32::from(group.sell_qty);
+            total_delta += f32::from(group.delta_qty());
+        }
+
+        let candle_center_x = match cluster_kind {
+            ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => {
+                ProfileArea::new(
+                    content_left,
+                    content_right,
+                    candle_width,
+                    spacing,
+                    imbalance.is_some(),
+                )
+                .candle_center_x
+            }
+            ClusterKind::BidAsk => {
+                BidAskArea::new(
+                    x_position,
+                    content_left,
+                    content_right,
+                    candle_width,
+                    spacing,
+                )
+                .candle_center_x
+            }
+        };
+
+        let summary_y = price_to_y(kline.low) + cell_height * 1.5;
+        let line_spacing = text_size * 1.2;
+
+        let total_vol = total_buy + total_sell;
+
+        draw_cluster_text(
+            frame,
+            &format!("V: {}", abbr_large_numbers(total_vol)),
+            Point::new(candle_center_x, summary_y),
+            text_size * 0.9,
+            palette.background.weakest.text,
+            Alignment::Center,
+            Alignment::Start,
+        );
+
+        let delta_color = if total_delta >= 0.0 {
+            palette.success.base.color
+        } else {
+            palette.danger.base.color
+        };
+
+        draw_cluster_text(
+            frame,
+            &format!("Δ: {}", abbr_large_numbers(total_delta)),
+            Point::new(candle_center_x, summary_y + line_spacing),
+            text_size * 0.9,
+            delta_color,
+            Alignment::Center,
+            Alignment::Start,
+        );
+    }
 }
 
 fn draw_imbalance_markers(

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1612,29 +1612,6 @@ fn draw_clusters(
             total_delta += f32::from(group.delta_qty());
         }
 
-        let candle_center_x = match cluster_kind {
-            ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => {
-                ProfileArea::new(
-                    content_left,
-                    content_right,
-                    candle_width,
-                    spacing,
-                    imbalance.is_some(),
-                )
-                .candle_center_x
-            }
-            ClusterKind::BidAsk => {
-                BidAskArea::new(
-                    x_position,
-                    content_left,
-                    content_right,
-                    candle_width,
-                    spacing,
-                )
-                .candle_center_x
-            }
-        };
-
         let summary_y = price_to_y(kline.low) + cell_height * 1.5;
         let line_spacing = text_size * 1.2;
 
@@ -1643,7 +1620,7 @@ fn draw_clusters(
         draw_cluster_text(
             frame,
             &format!("V: {}", abbr_large_numbers(total_vol)),
-            Point::new(candle_center_x, summary_y),
+            Point::new(x_position, summary_y),
             text_size * 0.9,
             palette.background.weakest.text,
             Alignment::Center,
@@ -1659,7 +1636,7 @@ fn draw_clusters(
         draw_cluster_text(
             frame,
             &format!("Δ: {}", abbr_large_numbers(total_delta)),
-            Point::new(candle_center_x, summary_y + line_spacing),
+            Point::new(x_position, summary_y + line_spacing),
             text_size * 0.9,
             delta_color,
             Alignment::Center,


### PR DESCRIPTION
I noticed the footprint chart candles is missing a HUD summary about volume delta of bid and ask, I integrated a fix for this that will be useful both visual and algo traders.

This is the result of the implementation below.
<img width="1741" height="860" alt="image" src="https://github.com/user-attachments/assets/2b7bde37-e574-4b09-9022-5dac5988b64e" />
