### PR TITLE
fix dashed lline in indicator plot when out of bounds

### DIFF
--- a/src/chart/indicator/plot.rs
+++ b/src/chart/indicator/plot.rs
@@ -490,7 +490,11 @@ where
                 let ratio = cursor_position.y / bounds.height;
                 let value = highest + ratio * (lowest - highest);
                 let rounded = round_to_tick(value, tick);
-                let snap_ratio = (rounded - highest) / (lowest - highest);
+                let snap_ratio = if lowest == highest {
+                    cursor_position.y / bounds.height
+                } else {
+                    (rounded - highest) / (lowest - highest)
+                };
 
                 frame.stroke(
                     &Path::line(


### PR DESCRIPTION
didnt quite understood the logic here but seems like its aint needed, sry if no.
Still when we are out of bounds on the plot, we get division by zero so either this fix or zero division check