### PR TITLE
support for tickers with unicode names

### DIFF
--- a/data/src/tickers_table.rs
+++ b/data/src/tickers_table.rs
@@ -103,8 +103,8 @@ pub fn calc_search_rank(ticker: &Ticker, query: &str) -> Option<SearchRank> {
     let (mut display_str, _) = ticker.display_symbol_and_type();
     let (mut raw_str, _) = ticker.to_full_symbol_and_type();
 
-    display_str.make_ascii_uppercase();
-    raw_str.make_ascii_uppercase();
+    display_str = display_str.to_uppercase();
+    raw_str = raw_str.to_uppercase();
 
     let suffix = market_suffix(ticker.market_type());
     let is_perp = !suffix.is_empty();

--- a/exchange/src/adapter.rs
+++ b/exchange/src/adapter.rs
@@ -518,7 +518,7 @@ impl Exchange {
     pub fn is_symbol_supported(&self, symbol: &str, log: bool) -> bool {
         let valid_symbol = symbol
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
 
         if valid_symbol {
             return true;

--- a/exchange/src/lib.rs
+++ b/exchange/src/lib.rs
@@ -298,7 +298,6 @@ impl Ticker {
         display_symbol: Option<&str>,
     ) -> Self {
         assert!(ticker.len() <= Self::MAX_LEN as usize, "Ticker too long");
-        assert!(ticker.is_ascii(), "Ticker must be ASCII");
         assert!(!ticker.contains('|'), "Ticker cannot contain '|'");
 
         let mut bytes = [0u8; Self::MAX_LEN as usize];

--- a/src/screen/dashboard/tickers_table.rs
+++ b/src/screen/dashboard/tickers_table.rs
@@ -991,8 +991,9 @@ impl TickersTable {
 
         let icon = icon_text(style::venue_icon(ticker.exchange.venue()), 12);
         let display_ticker = {
-            if display_data.display_ticker.len() >= 11 {
-                format!("{}...", &display_data.display_ticker[..9])
+            if display_data.display_ticker.chars().count() >= 11 {
+                let truncated: String = display_data.display_ticker.chars().take(9).collect();
+                format!("{}...", truncated)
             } else {
                 format!(
                     "{}{}",


### PR DESCRIPTION
Proposal to add unicode tickers.
Example: 币安人生 on binance

Not shure if it breaks something