### PR TITLE
Widen `Qty`/`Price` float conversions to f64

### DIFF
--- a/data/src/aggr/ticks.rs
+++ b/data/src/aggr/ticks.rs
@@ -240,7 +240,7 @@ impl TickAggr {
 
     pub fn min_max_price_in_range(&self, earliest: usize, latest: usize) -> Option<(f32, f32)> {
         self.min_max_price_in_range_prices(earliest, latest)
-            .map(|(min_p, max_p)| (min_p.to_f32(), max_p.to_f32()))
+            .map(|(min_p, max_p)| (min_p.to_f32_lossy(), max_p.to_f32_lossy()))
     }
 
     pub fn min_max_footprint_price_in_range(

--- a/data/src/aggr/time.rs
+++ b/data/src/aggr/time.rs
@@ -122,7 +122,7 @@ impl<D: DataPoint> TimeSeries<D> {
 
     pub fn min_max_price_in_range(&self, earliest: UnixMs, latest: UnixMs) -> Option<(f32, f32)> {
         self.min_max_price_in_range_prices(earliest, latest)
-            .map(|(min_p, max_p)| (min_p.to_f32(), max_p.to_f32()))
+            .map(|(min_p, max_p)| (min_p.to_f32_lossy(), max_p.to_f32_lossy()))
     }
 
     /// Ensures a datapoint bucket exists at `rounded_t` and ingests all trades into it.

--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -1,5 +1,6 @@
 use crate::util::ok_or_default;
 use exchange::SerTicker;
+use exchange::unit::qty::Qty;
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -7,14 +8,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub enum Threshold {
     Count(usize),
-    Qty(f32),
+    Qty(Qty),
 }
 
 impl std::fmt::Display for Threshold {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Threshold::Count(count) => write!(f, "Count based: {}", count),
-            Threshold::Qty(qty) => write!(f, "Qty based: {:.2}", qty),
+            Threshold::Qty(qty) => write!(f, "Qty based: {:.2}", qty.to_f64()),
         }
     }
 }

--- a/data/src/chart/heatmap.rs
+++ b/data/src/chart/heatmap.rs
@@ -329,7 +329,7 @@ impl HistoricalDepth {
                         *price_at_level,
                         size_in_quote_ccy,
                     );
-                    order_size > order_size_filter
+                    order_size as f32 > order_size_filter
                 })
                 .collect::<Vec<&OrderRun>>();
 
@@ -500,7 +500,7 @@ impl HistoricalDepth {
 
                 let order_size = market_type.qty_in_quote_value(run.qty, *price, size_in_quote_ccy);
 
-                if order_size > order_size_filter {
+                if order_size as f32 > order_size_filter {
                     max_depth_qty = max_depth_qty.max(run.qty);
                 }
             }

--- a/data/src/chart/kline.rs
+++ b/data/src/chart/kline.rs
@@ -227,7 +227,7 @@ impl KlineTrades {
             return;
         }
 
-        let mut max_volume = Qty::zero();
+        let mut max_volume = Qty::ZERO;
         let mut poc_price = Price::from_f32(0.0);
 
         for (price, group) in &self.trades {
@@ -446,7 +446,7 @@ impl Default for PointOfControl {
     fn default() -> Self {
         Self {
             price: Price::from_f32(0.0),
-            volume: Qty::zero(),
+            volume: Qty::ZERO,
             status: NPoc::default(),
         }
     }

--- a/data/src/util.rs
+++ b/data/src/util.rs
@@ -15,13 +15,13 @@ where
     Ok(T::deserialize(v).unwrap_or_default())
 }
 
-pub fn abbr_large_numbers(value: f32) -> String {
+pub fn abbr_large_numbers(value: f64) -> String {
     let abs_value = value.abs();
     let sign = if value < 0.0 { "-" } else { "" };
 
     match abs_value {
         v if v >= 1_000_000_000.0 => {
-            format!("{}{:.3}b", sign, v / 100_000_000.0)
+            format!("{}{:.3}b", sign, v / 1_000_000_000.0)
         }
         v if v >= 1_000_000.0 => format!("{}{:.2}m", sign, v / 1_000_000.0),
         v if v >= 10_000.0 => format!("{}{:.1}k", sign, v / 1_000.0),
@@ -43,7 +43,7 @@ pub fn abbr_large_numbers(value: f32) -> String {
     }
 }
 
-pub fn format_with_commas(num: f32) -> String {
+pub fn format_with_commas(num: f64) -> String {
     if num == 0.0 {
         return "0".to_string();
     }

--- a/exchange/src/adapter.rs
+++ b/exchange/src/adapter.rs
@@ -22,10 +22,6 @@ pub use proxy::Proxy;
 /// Buffer trades and flush in this interval
 const TRADE_BUCKET_INTERVAL: Duration = Duration::from_micros(33_333);
 
-pub fn allowed_multipliers_for_min_tick(min_ticksize: crate::unit::MinTicksize) -> &'static [u16] {
-    hub::hyperliquid::allowed_multipliers_for_min_tick(min_ticksize)
-}
-
 async fn flush_trade_buffers<V>(
     output: &mut futures::channel::mpsc::Sender<Event>,
     ticker_info_map: &FxHashMap<Ticker, (TickerInfo, V)>,
@@ -513,6 +509,30 @@ impl Exchange {
         } else {
             StreamTicksize::ServerSide(multiplier.unwrap_or(server_fallback))
         }
+    }
+
+    pub fn allowed_tick_multipliers(
+        &self,
+        min_ticksize: Option<super::unit::MinTicksize>,
+    ) -> Vec<TickMultiplier> {
+        if self.is_depth_client_aggr() {
+            return TickMultiplier::ALL.to_vec();
+        }
+
+        let Some(min_tick) = min_ticksize else {
+            return vec![];
+        };
+
+        let allowed = match self.venue() {
+            Venue::Hyperliquid => hub::hyperliquid::allowed_multipliers_for_min_tick(min_tick),
+            _ => return TickMultiplier::ALL.to_vec(),
+        };
+
+        TickMultiplier::ALL
+            .iter()
+            .copied()
+            .filter(|tm| allowed.contains(&tm.0))
+            .collect()
     }
 
     pub fn is_symbol_supported(&self, symbol: &str, log: bool) -> bool {

--- a/exchange/src/adapter.rs
+++ b/exchange/src/adapter.rs
@@ -74,8 +74,8 @@ impl MarketKind {
         MarketKind::InversePerps,
     ];
 
-    pub fn qty_in_quote_value(&self, qty: Qty, price: Price, size_in_quote_ccy: bool) -> f32 {
-        let qty = qty.to_f32_lossy();
+    pub fn qty_in_quote_value(&self, qty: Qty, price: Price, size_in_quote_ccy: bool) -> f64 {
+        let qty = qty.to_f64();
 
         match self {
             MarketKind::InversePerps => qty,
@@ -83,7 +83,7 @@ impl MarketKind {
                 if size_in_quote_ccy {
                     qty
                 } else {
-                    price.to_f32() * qty
+                    price.to_f64() * qty
                 }
             }
         }

--- a/exchange/src/adapter/client.rs
+++ b/exchange/src/adapter/client.rs
@@ -262,7 +262,7 @@ impl AdapterHandles {
         &self,
         venue: Venue,
         markets: &[MarketKind],
-        contract_sizes: Option<HashMap<Ticker, f32>>,
+        contract_sizes: Option<HashMap<Ticker, crate::unit::ContractSize>>,
     ) -> Result<HashMap<Ticker, TickerStats>, AdapterError> {
         match venue {
             Venue::Binance => {

--- a/exchange/src/adapter/hub/binance.rs
+++ b/exchange/src/adapter/hub/binance.rs
@@ -1,9 +1,8 @@
 use crate::{
     Event, Kline, OpenInterest, PushFrequency, Ticker, TickerInfo, Timeframe, Trade, UnixMs,
-    adapter::limiter::DynamicRateLimiterConfig,
-    adapter::{Exchange, MarketKind},
+    adapter::{Exchange, MarketKind, limiter::DynamicRateLimiterConfig},
     depth::DepthPayload,
-    unit::qty::RawQtyUnit,
+    unit::{ContractSize, qty::RawQtyUnit},
 };
 
 use super::{AdapterError, HttpHub, RequestPort};
@@ -80,7 +79,7 @@ pub type BinanceLimiter = crate::adapter::limiter::HeaderDynamicRateLimiter;
 #[derive(Debug, Clone)]
 pub struct BinanceMarketScope {
     pub market: MarketKind,
-    pub contract_sizes: Option<HashMap<Ticker, f32>>,
+    pub contract_sizes: Option<HashMap<Ticker, ContractSize>>,
 }
 
 impl BinanceMarketScope {
@@ -91,7 +90,10 @@ impl BinanceMarketScope {
         }
     }
 
-    pub fn stats(market: MarketKind, contract_sizes: Option<HashMap<Ticker, f32>>) -> Self {
+    pub fn stats(
+        market: MarketKind,
+        contract_sizes: Option<HashMap<Ticker, ContractSize>>,
+    ) -> Self {
         Self {
             market,
             contract_sizes,

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -313,7 +313,7 @@ pub(super) async fn fetch_ticker_stats(
         };
 
         let daily_volume = match market {
-            MarketKind::Spot | MarketKind::LinearPerps => Qty::from_f32(volume),
+            MarketKind::Spot | MarketKind::LinearPerps => Qty::from_f32_lossy(volume),
             MarketKind::InversePerps => {
                 let contract_size = match contract_sizes
                     .and_then(|sizes| sizes.get(&ticker))
@@ -326,7 +326,7 @@ pub(super) async fn fetch_ticker_stats(
                     }
                 };
 
-                Qty::from_f32(volume * contract_size)
+                Qty::from_f32_lossy(volume * contract_size)
             }
         };
 

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -305,28 +305,28 @@ pub(super) async fn fetch_ticker_stats(
 
         let volume = match market {
             MarketKind::Spot | MarketKind::LinearPerps => {
-                serde_util::value_as_f32(&item["quoteVolume"])
+                serde_util::value_as_f64(&item["quoteVolume"])
                     .ok_or_else(|| AdapterError::ParseError("Quote volume not found".to_string()))?
             }
-            MarketKind::InversePerps => serde_util::value_as_f32(&item["volume"])
+            MarketKind::InversePerps => serde_util::value_as_f64(&item["volume"])
                 .ok_or_else(|| AdapterError::ParseError("Volume not found".to_string()))?,
         };
 
         let daily_volume = match market {
-            MarketKind::Spot | MarketKind::LinearPerps => Qty::from_f32_lossy(volume),
+            MarketKind::Spot | MarketKind::LinearPerps => Qty::from_f64(volume),
             MarketKind::InversePerps => {
                 let contract_size = match contract_sizes
                     .and_then(|sizes| sizes.get(&ticker))
                     .copied()
                 {
-                    Some(size) => size,
+                    Some(size) => size as f64,
                     None => {
                         log::debug!("Missing contract size for {ticker}, skipping ticker in stats");
                         continue;
                     }
                 };
 
-                Qty::from_f32_lossy(volume * contract_size)
+                Qty::from_f64(volume * contract_size)
             }
         };
 

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -20,15 +20,15 @@ use std::{collections::HashMap, io::BufReader, path::PathBuf, time::UNIX_EPOCH};
 #[derive(Deserialize, Debug, Clone)]
 struct FetchedKline(
     u64,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
     u64,
     String,
     u32,
-    #[serde(deserialize_with = "de_string_to_number")] f32,
+    #[serde(deserialize_with = "de_string_to_number")] f64,
     String,
     String,
 );
@@ -39,7 +39,7 @@ struct DeOpenInterest {
     #[serde(rename = "timestamp")]
     pub time: u64,
     #[serde(rename = "sumOpenInterest", deserialize_with = "de_string_to_number")]
-    pub sum: f32,
+    pub sum: f64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -47,9 +47,9 @@ struct DeTrade {
     #[serde(rename = "T")]
     time: u64,
     #[serde(rename = "p", deserialize_with = "de_string_to_number")]
-    price: f32,
+    price: f64,
     #[serde(rename = "q", deserialize_with = "de_string_to_number")]
-    qty: f32,
+    qty: f64,
     #[serde(rename = "m")]
     is_sell: bool,
 }
@@ -250,7 +250,7 @@ pub(super) async fn fetch_ticker_metadata(
                     .ok_or_else(|| AdapterError::ParseError("Failed to parse minQty".to_string()))
             })?;
 
-        let contract_size = serde_util::value_as_f32(&item["contractSize"]);
+        let contract_size = serde_util::value_as_f64(&item["contractSize"]);
 
         let ticker = Ticker::new(symbol_str, exchange);
 
@@ -539,7 +539,7 @@ pub(super) async fn fetch_historical_oi(
         .iter()
         .map(|x| OpenInterest {
             time: x.time.into(),
-            value: contract_size.map_or(x.sum, |size| x.sum * size.as_f32()),
+            value: contract_size.map_or(x.sum, |size| x.sum * size.as_f64()),
         })
         .collect::<Vec<OpenInterest>>();
 
@@ -576,7 +576,7 @@ async fn fetch_intraday_trades(
         .map(|de_trade| Trade {
             time: de_trade.time.into(),
             is_sell: de_trade.is_sell,
-            price: Price::from_f32(de_trade.price).round_to_min_tick(ticker_info.min_ticksize),
+            price: Price::from_f64(de_trade.price).round_to_min_tick(ticker_info.min_ticksize),
             qty: qty_norm.normalize_qty(de_trade.qty, de_trade.price),
         })
         .collect();
@@ -663,10 +663,10 @@ async fn get_hist_trades_with_client(
             record.ok().and_then(|record| {
                 let time = record[5].parse::<u64>().ok()?;
                 let is_sell = record[6].parse::<bool>().ok()?;
-                let price_f32 = record[1].parse::<f32>().ok()?;
+                let price_f64 = record[1].parse::<f64>().ok()?;
 
-                let price = Price::from_f32(price_f32).round_to_min_tick(ticker_info.min_ticksize);
-                let qty = qty_norm.normalize_qty(record[2].parse::<f32>().ok()?, price_f32);
+                let price = Price::from_f64(price_f64).round_to_min_tick(ticker_info.min_ticksize);
+                let qty = qty_norm.normalize_qty(record[2].parse::<f64>().ok()?, price_f64);
 
                 Some(Trade {
                     time: time.into(),

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -295,7 +295,7 @@ pub(super) async fn fetch_ticker_stats(
 
         let ticker = Ticker::new(symbol, exchange);
 
-        let last_price = serde_util::value_as_f32(&item["lastPrice"])
+        let last_price = serde_util::value_as_f64(&item["lastPrice"])
             .ok_or_else(|| AdapterError::ParseError("Last price not found".to_string()))?;
 
         let price_change_pt =
@@ -331,7 +331,7 @@ pub(super) async fn fetch_ticker_stats(
         };
 
         let ticker_stats = TickerStats {
-            mark_price: Price::from_f32(last_price),
+            mark_price: Price::from_f64(last_price),
             daily_price_chg: price_change_pt,
             daily_volume,
         };

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -271,7 +271,7 @@ pub(super) async fn fetch_ticker_metadata(
 pub(super) async fn fetch_ticker_stats(
     hub: &mut HttpHub<BinanceLimiter>,
     market: MarketKind,
-    contract_sizes: Option<&HashMap<Ticker, f32>>,
+    contract_sizes: Option<&HashMap<Ticker, crate::unit::ContractSize>>,
 ) -> Result<super::super::TickerStatsMap, AdapterError> {
     let (url, weight) = match market {
         MarketKind::Spot => (format!("{SPOT_DOMAIN}/api/v3/ticker/24hr"), 80),
@@ -319,7 +319,7 @@ pub(super) async fn fetch_ticker_stats(
                     .and_then(|sizes| sizes.get(&ticker))
                     .copied()
                 {
-                    Some(size) => size as f64,
+                    Some(size) => size.as_f64(),
                     None => {
                         log::debug!("Missing contract size for {ticker}, skipping ticker in stats");
                         continue;

--- a/exchange/src/adapter/hub/binance/fetch.rs
+++ b/exchange/src/adapter/hub/binance/fetch.rs
@@ -250,7 +250,7 @@ pub(super) async fn fetch_ticker_metadata(
                     .ok_or_else(|| AdapterError::ParseError("Failed to parse minQty".to_string()))
             })?;
 
-        let contract_size = serde_util::value_as_f64(&item["contractSize"]);
+        let contract_size = serde_util::value_as_f32(&item["contractSize"]);
 
         let ticker = Ticker::new(symbol_str, exchange);
 

--- a/exchange/src/adapter/hub/binance/stream.rs
+++ b/exchange/src/adapter/hub/binance/stream.rs
@@ -264,17 +264,17 @@ struct SonicKline {
     #[serde(rename = "t")]
     time: u64,
     #[serde(rename = "o", deserialize_with = "de_string_to_number")]
-    open: f32,
+    open: f64,
     #[serde(rename = "h", deserialize_with = "de_string_to_number")]
-    high: f32,
+    high: f64,
     #[serde(rename = "l", deserialize_with = "de_string_to_number")]
-    low: f32,
+    low: f64,
     #[serde(rename = "c", deserialize_with = "de_string_to_number")]
-    close: f32,
+    close: f64,
     #[serde(rename = "v", deserialize_with = "de_string_to_number")]
-    volume: f32,
+    volume: f64,
     #[serde(rename = "V", deserialize_with = "de_string_to_number")]
-    taker_buy_base_asset_volume: f32,
+    taker_buy_base_asset_volume: f64,
     #[serde(rename = "i")]
     interval: String,
 }
@@ -292,9 +292,9 @@ struct SonicTrade {
     #[serde(rename = "T")]
     time: u64,
     #[serde(rename = "p", deserialize_with = "de_string_to_number")]
-    price: f32,
+    price: f64,
     #[serde(rename = "q", deserialize_with = "de_string_to_number")]
-    qty: f32,
+    qty: f64,
     #[serde(rename = "m")]
     is_sell: bool,
 }
@@ -765,7 +765,7 @@ pub fn connect_trade_stream(
                                         ticker_info_map.get(&ticker)
                                     {
                                         let ticker_info = *ticker_info;
-                                        let price = Price::from_f32(de_trade.price)
+                                        let price = Price::from_f64(de_trade.price)
                                             .round_to_min_tick(ticker_info.min_ticksize);
 
                                         let trade = Trade {

--- a/exchange/src/adapter/hub/bybit/fetch.rs
+++ b/exchange/src/adapter/hub/bybit/fetch.rs
@@ -154,7 +154,7 @@ pub(super) async fn fetch_ticker_stats(
             continue;
         }
 
-        let mark_price = serde_util::value_as_f32(&item["lastPrice"])
+        let mark_price = serde_util::value_as_f64(&item["lastPrice"])
             .ok_or_else(|| AdapterError::ParseError("Mark price not found".to_string()))?;
 
         let daily_price_chg = serde_util::value_as_f32(&item["price24hPcnt"])
@@ -166,11 +166,11 @@ pub(super) async fn fetch_ticker_stats(
         let volume_in_usd = if market_type == MarketKind::InversePerps {
             daily_volume
         } else {
-            daily_volume * mark_price as f64
+            daily_volume * mark_price
         };
 
         let ticker_stats = TickerStats {
-            mark_price: Price::from_f32(mark_price),
+            mark_price: Price::from_f64(mark_price),
             daily_price_chg: daily_price_chg * 100.0,
             daily_volume: Qty::from_f64(volume_in_usd),
         };

--- a/exchange/src/adapter/hub/bybit/fetch.rs
+++ b/exchange/src/adapter/hub/bybit/fetch.rs
@@ -160,19 +160,19 @@ pub(super) async fn fetch_ticker_stats(
         let daily_price_chg = serde_util::value_as_f32(&item["price24hPcnt"])
             .ok_or_else(|| AdapterError::ParseError("Daily price change not found".to_string()))?;
 
-        let daily_volume = serde_util::value_as_f32(&item["volume24h"])
+        let daily_volume = serde_util::value_as_f64(&item["volume24h"])
             .ok_or_else(|| AdapterError::ParseError("Daily volume not found".to_string()))?;
 
         let volume_in_usd = if market_type == MarketKind::InversePerps {
             daily_volume
         } else {
-            daily_volume * mark_price
+            daily_volume * mark_price as f64
         };
 
         let ticker_stats = TickerStats {
             mark_price: Price::from_f32(mark_price),
             daily_price_chg: daily_price_chg * 100.0,
-            daily_volume: Qty::from_f32_lossy(volume_in_usd),
+            daily_volume: Qty::from_f64(volume_in_usd),
         };
 
         ticker_prices_map.insert(Ticker::new(symbol, exchange), ticker_stats);

--- a/exchange/src/adapter/hub/bybit/fetch.rs
+++ b/exchange/src/adapter/hub/bybit/fetch.rs
@@ -21,7 +21,7 @@ struct DeOpenInterest {
         rename = "openInterest",
         deserialize_with = "serde_util::de_string_to_number"
     )]
-    pub value: f32,
+    pub value: f64,
     #[serde(deserialize_with = "serde_util::de_string_to_number")]
     pub timestamp: u64,
 }
@@ -236,12 +236,12 @@ pub(super) async fn fetch_klines(
         .map(|kline| {
             let time = parse_kline_field::<u64>(kline[0].as_str())?;
 
-            let open = parse_kline_field::<f32>(kline[1].as_str())?;
-            let high = parse_kline_field::<f32>(kline[2].as_str())?;
-            let low = parse_kline_field::<f32>(kline[3].as_str())?;
-            let close = parse_kline_field::<f32>(kline[4].as_str())?;
+            let open = parse_kline_field::<f64>(kline[1].as_str())?;
+            let high = parse_kline_field::<f64>(kline[2].as_str())?;
+            let low = parse_kline_field::<f64>(kline[3].as_str())?;
+            let close = parse_kline_field::<f64>(kline[4].as_str())?;
 
-            let volume = parse_kline_field::<f32>(kline[5].as_str())?;
+            let volume = parse_kline_field::<f64>(kline[5].as_str())?;
             let volume = qty_norm.normalize_qty(volume, close);
 
             let kline = Kline::new(

--- a/exchange/src/adapter/hub/bybit/fetch.rs
+++ b/exchange/src/adapter/hub/bybit/fetch.rs
@@ -172,7 +172,7 @@ pub(super) async fn fetch_ticker_stats(
         let ticker_stats = TickerStats {
             mark_price: Price::from_f32(mark_price),
             daily_price_chg: daily_price_chg * 100.0,
-            daily_volume: Qty::from_f32(volume_in_usd),
+            daily_volume: Qty::from_f32_lossy(volume_in_usd),
         };
 
         ticker_prices_map.insert(Ticker::new(symbol, exchange), ticker_stats);

--- a/exchange/src/adapter/hub/bybit/stream.rs
+++ b/exchange/src/adapter/hub/bybit/stream.rs
@@ -31,9 +31,9 @@ struct SonicTrade {
     #[serde(rename = "T")]
     pub time: u64,
     #[serde(rename = "p", deserialize_with = "de_string_to_number")]
-    pub price: f32,
+    pub price: f64,
     #[serde(rename = "v", deserialize_with = "de_string_to_number")]
-    pub qty: f32,
+    pub qty: f64,
     #[serde(rename = "S")]
     pub is_sell: String,
 }
@@ -43,15 +43,15 @@ pub struct SonicKline {
     #[serde(rename = "start")]
     pub time: u64,
     #[serde(rename = "open", deserialize_with = "de_string_to_number")]
-    pub open: f32,
+    pub open: f64,
     #[serde(rename = "high", deserialize_with = "de_string_to_number")]
-    pub high: f32,
+    pub high: f64,
     #[serde(rename = "low", deserialize_with = "de_string_to_number")]
-    pub low: f32,
+    pub low: f64,
     #[serde(rename = "close", deserialize_with = "de_string_to_number")]
-    pub close: f32,
+    pub close: f64,
     #[serde(rename = "volume", deserialize_with = "de_string_to_number")]
-    pub volume: f32,
+    pub volume: f64,
     #[serde(rename = "interval")]
     pub interval: String,
 }
@@ -472,7 +472,7 @@ pub fn connect_trade_stream(
                                     let trades_buffer =
                                         trades_buffer_map.entry(ticker).or_default();
                                     for de_trade in &de_trade_vec {
-                                        let price = Price::from_f32(de_trade.price)
+                                        let price = Price::from_f64(de_trade.price)
                                             .round_to_min_tick(ticker_info.min_ticksize);
 
                                         let trade = Trade {

--- a/exchange/src/adapter/hub/hyperliquid.rs
+++ b/exchange/src/adapter/hub/hyperliquid.rs
@@ -29,6 +29,7 @@ const MULTS_FRACTIONAL: &[u16] = &[1, 2, 5, 10, 100, 1000];
 // safe intersection when base tick is exactly 1 (cannot disambiguate boundary case)
 const MULTS_SAFE: &[u16] = &[1, 10, 100, 1000];
 
+/// Allowed multipliers based on observed Hyperliquid tick rules.
 pub fn allowed_multipliers_for_min_tick(min_ticksize: MinTicksize) -> &'static [u16] {
     if min_ticksize.power < 0 {
         // int_digits <= 4 (fractional/boundary region)

--- a/exchange/src/adapter/hub/hyperliquid/fetch.rs
+++ b/exchange/src/adapter/hub/hyperliquid/fetch.rs
@@ -257,14 +257,14 @@ fn insert_ticker_from_ctx(
         return;
     }
 
-    let ticker_info = create_ticker_info(ticker, price as f32, sz_decimals);
+    let ticker_info = create_ticker_info(ticker, price, sz_decimals);
     ticker_info_map.insert(ticker, Some(ticker_info));
 
     ticker_stats_map.insert(
         ticker,
         TickerStats {
             mark_price: Price::from_f64(ctx.mark_price),
-            daily_price_chg: daily_price_chg_pct(price as f32, ctx.prev_day_price as f32),
+            daily_price_chg: daily_price_chg_pct(price, ctx.prev_day_price),
             daily_volume: Qty::from_f64(ctx.day_notional_volume),
         },
     );
@@ -364,7 +364,7 @@ fn process_spot_assets(
     Ok((ticker_info_map, ticker_stats_map))
 }
 
-fn create_ticker_info(ticker: Ticker, price: f32, sz_decimals: u32) -> TickerInfo {
+fn create_ticker_info(ticker: Ticker, price: f64, sz_decimals: u32) -> TickerInfo {
     let market = ticker.market_type();
 
     let tick_size = compute_tick_size(price, sz_decimals, market);
@@ -392,15 +392,15 @@ fn create_display_symbol(
     }
 }
 
-fn daily_price_chg_pct(price: f32, prev_day_price: f32) -> f32 {
+fn daily_price_chg_pct(price: f64, prev_day_price: f64) -> f32 {
     if prev_day_price > 0.0 {
-        ((price - prev_day_price) / prev_day_price) * 100.0
+        (((price - prev_day_price) / prev_day_price) * 100.0) as f32
     } else {
         0.0
     }
 }
 
-fn compute_tick_size(price: f32, sz_decimals: u32, market: MarketKind) -> f32 {
+fn compute_tick_size(price: f64, sz_decimals: u32, market: MarketKind) -> f32 {
     if price <= 0.0 {
         return 0.001;
     }

--- a/exchange/src/adapter/hub/hyperliquid/fetch.rs
+++ b/exchange/src/adapter/hub/hyperliquid/fetch.rs
@@ -41,17 +41,17 @@ struct HyperliquidSpotMeta {
 #[derive(Debug, Deserialize)]
 struct HyperliquidAssetContext {
     #[serde(rename = "dayNtlVlm", deserialize_with = "de_string_to_number")]
-    day_notional_volume: f32,
+    day_notional_volume: f64,
     #[serde(rename = "markPx", deserialize_with = "de_string_to_number")]
-    mark_price: f32,
+    mark_price: f64,
     #[serde(rename = "midPx", deserialize_with = "de_string_to_number")]
-    mid_price: f32,
+    mid_price: f64,
     #[serde(rename = "prevDayPx", deserialize_with = "de_string_to_number")]
-    prev_day_price: f32,
+    prev_day_price: f64,
 }
 
 impl HyperliquidAssetContext {
-    fn price(&self) -> f32 {
+    fn price(&self) -> f64 {
         if self.mid_price > 0.0 {
             self.mid_price
         } else {
@@ -72,15 +72,15 @@ struct HyperliquidKline {
     #[serde(rename = "i")]
     interval: String,
     #[serde(rename = "o", deserialize_with = "de_string_to_number")]
-    open: f32,
+    open: f64,
     #[serde(rename = "h", deserialize_with = "de_string_to_number")]
-    high: f32,
+    high: f64,
     #[serde(rename = "l", deserialize_with = "de_string_to_number")]
-    low: f32,
+    low: f64,
     #[serde(rename = "c", deserialize_with = "de_string_to_number")]
-    close: f32,
+    close: f64,
     #[serde(rename = "v", deserialize_with = "de_string_to_number")]
-    volume: f32,
+    volume: f64,
     #[serde(rename = "n")]
     trade_count: u64,
 }
@@ -94,9 +94,9 @@ struct HyperliquidDepth {
 #[derive(Debug, Deserialize)]
 struct HyperliquidLevel {
     #[serde(deserialize_with = "de_string_to_number")]
-    px: f32,
+    px: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    sz: f32,
+    sz: f64,
 }
 
 type TickerMetadata = (
@@ -257,15 +257,15 @@ fn insert_ticker_from_ctx(
         return;
     }
 
-    let ticker_info = create_ticker_info(ticker, price, sz_decimals);
+    let ticker_info = create_ticker_info(ticker, price as f32, sz_decimals);
     ticker_info_map.insert(ticker, Some(ticker_info));
 
     ticker_stats_map.insert(
         ticker,
         TickerStats {
-            mark_price: Price::from_f32(ctx.mark_price),
-            daily_price_chg: daily_price_chg_pct(price, ctx.prev_day_price),
-            daily_volume: Qty::from_f32(ctx.day_notional_volume),
+            mark_price: Price::from_f64(ctx.mark_price),
+            daily_price_chg: daily_price_chg_pct(price as f32, ctx.prev_day_price as f32),
+            daily_volume: Qty::from_f64(ctx.day_notional_volume),
         },
     );
 }

--- a/exchange/src/adapter/hub/hyperliquid/stream.rs
+++ b/exchange/src/adapter/hub/hyperliquid/stream.rs
@@ -111,9 +111,9 @@ struct HyperliquidDepth {
 #[derive(Debug, Deserialize)]
 struct HyperliquidLevel {
     #[serde(deserialize_with = "de_string_to_number")]
-    px: f32,
+    px: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    sz: f32,
+    sz: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -121,9 +121,9 @@ struct HyperliquidTrade {
     coin: String,
     side: String,
     #[serde(deserialize_with = "de_string_to_number")]
-    px: f32,
+    px: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    sz: f32,
+    sz: f64,
     time: u64,
 }
 
@@ -136,15 +136,15 @@ struct HyperliquidKline {
     #[serde(rename = "i")]
     interval: String,
     #[serde(rename = "o", deserialize_with = "de_string_to_number")]
-    open: f32,
+    open: f64,
     #[serde(rename = "h", deserialize_with = "de_string_to_number")]
-    high: f32,
+    high: f64,
     #[serde(rename = "l", deserialize_with = "de_string_to_number")]
-    low: f32,
+    low: f64,
     #[serde(rename = "c", deserialize_with = "de_string_to_number")]
-    close: f32,
+    close: f64,
     #[serde(rename = "v", deserialize_with = "de_string_to_number")]
-    volume: f32,
+    volume: f64,
 }
 
 enum StreamData {
@@ -245,7 +245,7 @@ pub fn connect_depth_stream(
                         continue;
                     };
 
-                    let depth_cfg = config_from_multiplier(best_bid_price, user_multiplier);
+                    let depth_cfg = config_from_multiplier(best_bid_price as f32, user_multiplier);
                     let snapshot_time = snapshot.time;
 
                     local_depth_cache.update_with_qty_norm(
@@ -496,7 +496,7 @@ pub fn connect_trade_stream(
                                             ticker_info_map.get(ticker)
                                     {
                                         let ticker_info = *ticker_info;
-                                        let price = Price::from_f32(hl_trade.px)
+                                        let price = Price::from_f64(hl_trade.px)
                                             .round_to_min_tick(ticker_info.min_ticksize);
 
                                         let trade = Trade {

--- a/exchange/src/adapter/hub/hyperliquid/stream.rs
+++ b/exchange/src/adapter/hub/hyperliquid/stream.rs
@@ -72,7 +72,7 @@ fn snap_multiplier_to_125(multiplier: u16) -> (i32, i32) {
     (kf as i32, mantissa)
 }
 
-fn config_from_multiplier(price: f32, multiplier: u16) -> DepthFeedConfig {
+fn config_from_multiplier(price: f64, multiplier: u16) -> DepthFeedConfig {
     if price <= 0.0 {
         return DepthFeedConfig::full_precision();
     }
@@ -245,7 +245,7 @@ pub fn connect_depth_stream(
                         continue;
                     };
 
-                    let depth_cfg = config_from_multiplier(best_bid_price as f32, user_multiplier);
+                    let depth_cfg = config_from_multiplier(best_bid_price, user_multiplier);
                     let snapshot_time = snapshot.time;
 
                     local_depth_cache.update_with_qty_norm(

--- a/exchange/src/adapter/hub/mexc.rs
+++ b/exchange/src/adapter/hub/mexc.rs
@@ -1,9 +1,8 @@
 use crate::{
     Event, Kline, PushFrequency, Ticker, TickerInfo, Timeframe, UnixMs,
-    adapter::limiter::FixedWindowRateLimiterConfig,
-    adapter::{Exchange, MarketKind},
+    adapter::{Exchange, MarketKind, limiter::FixedWindowRateLimiterConfig},
     depth::DepthPayload,
-    unit::qty::RawQtyUnit,
+    unit::{ContractSize, qty::RawQtyUnit},
 };
 
 use super::{AdapterError, HttpHub, RequestPort};
@@ -39,11 +38,11 @@ fn contract_size_for_market(
     ticker_info: TickerInfo,
     market: MarketKind,
     context: &str,
-) -> Result<f32, AdapterError> {
+) -> Result<ContractSize, AdapterError> {
     match market {
-        MarketKind::Spot => Ok(1.0),
+        MarketKind::Spot => Ok(ContractSize::new(0)), // 10^0 = 1.0
         MarketKind::LinearPerps | MarketKind::InversePerps => {
-            ticker_info.contract_size.map(f32::from).ok_or_else(|| {
+            ticker_info.contract_size.ok_or_else(|| {
                 AdapterError::ParseError(format!(
                     "Missing contract size for {} in {context}",
                     ticker_info.ticker
@@ -55,7 +54,7 @@ fn contract_size_for_market(
 
 fn mexc_perps_market_from_symbol(
     symbol: &str,
-    contract_sizes: Option<&HashMap<Ticker, f32>>,
+    contract_sizes: Option<&HashMap<Ticker, ContractSize>>,
 ) -> Option<MarketKind> {
     if symbol.ends_with("USDT") {
         return Some(MarketKind::LinearPerps);
@@ -135,7 +134,7 @@ pub type MexcLimiter = crate::adapter::limiter::FixedWindowRateLimiter;
 #[derive(Debug, Clone, Default)]
 pub struct MexcMarketScope {
     pub markets: Vec<MarketKind>,
-    pub contract_sizes: Option<HashMap<Ticker, f32>>,
+    pub contract_sizes: Option<HashMap<Ticker, ContractSize>>,
 }
 
 impl MexcMarketScope {
@@ -146,7 +145,10 @@ impl MexcMarketScope {
         }
     }
 
-    pub fn stats(markets: &[MarketKind], contract_sizes: Option<HashMap<Ticker, f32>>) -> Self {
+    pub fn stats(
+        markets: &[MarketKind],
+        contract_sizes: Option<HashMap<Ticker, ContractSize>>,
+    ) -> Self {
         Self {
             markets: markets.to_vec(),
             contract_sizes,

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -29,19 +29,19 @@ struct KlineSpot {
     #[serde()]
     open_ts: u64,
     #[serde(deserialize_with = "de_string_to_number")]
-    open: f32,
+    open: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    high: f32,
+    high: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    low: f32,
+    low: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    close: f32,
+    close: f64,
     #[serde(deserialize_with = "de_string_to_number")]
-    vol: f32,
+    vol: f64,
     #[serde()]
     close_ts: u64,
     #[serde(deserialize_with = "de_string_to_number")]
-    asset_vol: f32,
+    asset_vol: f64,
 }
 
 #[derive(Deserialize)]
@@ -220,10 +220,9 @@ pub(super) async fn fetch_ticker_metadata(
 
             let contract_size = item["contractSize"]
                 .as_f64()
-                .ok_or_else(|| AdapterError::ParseError("Missing contractSize".to_string()))?
-                as f32;
+                .ok_or_else(|| AdapterError::ParseError("Missing contractSize".to_string()))?;
 
-            let min_qty = min_qty_contracts * contract_size;
+            let min_qty = (min_qty_contracts as f64 * contract_size) as f32;
 
             let ticker = Ticker::new(symbol, exchange);
             let info = TickerInfo::new(ticker, min_ticksize, min_qty, Some(contract_size));
@@ -474,22 +473,22 @@ pub(super) async fn fetch_klines(
 
                     let open = opens[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("Open value not found".to_string())
-                    })? as f32;
+                    })?;
                     let high = highs[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("High value not found".to_string())
-                    })? as f32;
+                    })?;
                     let low = lows[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("Low value not found".to_string())
-                    })? as f32;
+                    })?;
                     let close = closes[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("Close value not found".to_string())
-                    })? as f32;
+                    })?;
                     let _amount = amounts[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("Amount value not found".to_string())
-                    })? as f32;
+                    })?;
                     let volume = volumes[i].as_f64().ok_or_else(|| {
                         AdapterError::ParseError("Vol value not found".to_string())
-                    })? as f32;
+                    })?;
 
                     let normalized_vol = qty_norm.normalize_qty(volume, close);
 

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -267,7 +267,7 @@ pub(super) async fn fetch_ticker_stats(
                 continue;
             }
 
-            let last_price = serde_util::value_as_f32(&item["lastPrice"])
+            let last_price = serde_util::value_as_f64(&item["lastPrice"])
                 .ok_or_else(|| AdapterError::ParseError("Last price not found".to_string()))?;
 
             let price_change_percent = serde_util::value_as_f32(&item["priceChangePercent"])
@@ -281,13 +281,13 @@ pub(super) async fn fetch_ticker_stats(
             let volume_in_usd = if let Some(qv) = serde_util::value_as_f64(&item["quoteVolume"]) {
                 qv
             } else {
-                volume * last_price as f64
+                volume * last_price
             };
 
             let daily_price_chg = price_change_percent * 100.0;
 
             let ticker_stats = TickerStats {
-                mark_price: Price::from_f32(last_price),
+                mark_price: Price::from_f64(last_price),
                 daily_price_chg,
                 daily_volume: Qty::from_f64(volume_in_usd),
             };
@@ -333,7 +333,7 @@ pub(super) async fn fetch_ticker_stats(
                 continue;
             };
 
-            let last_price = serde_util::value_as_f32(&item["lastPrice"])
+            let last_price = serde_util::value_as_f64(&item["lastPrice"])
                 .ok_or_else(|| AdapterError::ParseError("Last price not found".to_string()))?;
 
             let rise_fall_rate = serde_util::value_as_f32(&item["riseFallRate"])
@@ -345,13 +345,13 @@ pub(super) async fn fetch_ticker_stats(
             let volume_in_usd = if perps_market == MarketKind::InversePerps {
                 volume_24 * cs.as_f64()
             } else {
-                volume_24 * cs.as_f64() * last_price as f64
+                volume_24 * cs.as_f64() * last_price
             };
 
             let daily_price_chg = rise_fall_rate * 100.0;
 
             let ticker_stats = TickerStats {
-                mark_price: Price::from_f32(last_price),
+                mark_price: Price::from_f64(last_price),
                 daily_price_chg,
                 daily_volume: Qty::from_f64(volume_in_usd),
             };

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -236,7 +236,7 @@ pub(super) async fn fetch_ticker_metadata(
 pub(super) async fn fetch_ticker_stats(
     hub: &mut HttpHub<MexcLimiter>,
     markets: &[MarketKind],
-    contract_sizes: Option<&HashMap<Ticker, f32>>,
+    contract_sizes: Option<&HashMap<Ticker, crate::unit::ContractSize>>,
 ) -> Result<super::super::TickerStatsMap, AdapterError> {
     let mut ticker_prices_map = HashMap::new();
 
@@ -346,9 +346,9 @@ pub(super) async fn fetch_ticker_stats(
                 .ok_or_else(|| AdapterError::ParseError("Missing volume24".to_string()))?;
 
             let volume_in_usd = if perps_market == MarketKind::InversePerps {
-                volume_24 * cs as f64
+                volume_24 * cs.as_f64()
             } else {
-                volume_24 * cs as f64 * last_price as f64
+                volume_24 * cs.as_f64() * last_price as f64
             };
 
             let daily_price_chg = rise_fall_rate * 100.0;

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -292,7 +292,7 @@ pub(super) async fn fetch_ticker_stats(
             let ticker_stats = TickerStats {
                 mark_price: Price::from_f32(last_price),
                 daily_price_chg,
-                daily_volume: Qty::from_f32(volume_in_usd),
+                daily_volume: Qty::from_f32_lossy(volume_in_usd),
             };
 
             ticker_prices_map.insert(Ticker::new(symbol, exchange), ticker_stats);
@@ -356,7 +356,7 @@ pub(super) async fn fetch_ticker_stats(
             let ticker_stats = TickerStats {
                 mark_price: Price::from_f32(last_price),
                 daily_price_chg,
-                daily_volume: Qty::from_f32(volume_in_usd),
+                daily_volume: Qty::from_f32_lossy(volume_in_usd),
             };
 
             ticker_prices_map.insert(ticker, ticker_stats);

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -209,20 +209,17 @@ pub(super) async fn fetch_ticker_metadata(
                 continue;
             }
 
-            let min_qty_contracts = item["minVol"]
-                .as_f64()
-                .ok_or_else(|| AdapterError::ParseError("Missing minVol (min_qty)".to_string()))?
-                as f32;
+            let min_qty_contracts = serde_util::value_as_f32(&item["minVol"])
+                .ok_or_else(|| AdapterError::ParseError("Missing minVol (min_qty)".to_string()))?;
 
-            let min_ticksize = item["priceUnit"].as_f64().ok_or_else(|| {
+            let min_ticksize = serde_util::value_as_f32(&item["priceUnit"]).ok_or_else(|| {
                 AdapterError::ParseError("Missing priceUnit (ticksize)".to_string())
-            })? as f32;
+            })?;
 
-            let contract_size = item["contractSize"]
-                .as_f64()
+            let contract_size = serde_util::value_as_f32(&item["contractSize"])
                 .ok_or_else(|| AdapterError::ParseError("Missing contractSize".to_string()))?;
 
-            let min_qty = (min_qty_contracts as f64 * contract_size) as f32;
+            let min_qty = min_qty_contracts * contract_size;
 
             let ticker = Ticker::new(symbol, exchange);
             let info = TickerInfo::new(ticker, min_ticksize, min_qty, Some(contract_size));

--- a/exchange/src/adapter/hub/mexc/fetch.rs
+++ b/exchange/src/adapter/hub/mexc/fetch.rs
@@ -278,13 +278,13 @@ pub(super) async fn fetch_ticker_stats(
                     AdapterError::ParseError("Price change percent not found".to_string())
                 })?;
 
-            let volume = serde_util::value_as_f32(&item["volume"])
+            let volume = serde_util::value_as_f64(&item["volume"])
                 .ok_or_else(|| AdapterError::ParseError("Volume not found".to_string()))?;
 
-            let volume_in_usd = if let Some(qv) = serde_util::value_as_f32(&item["quoteVolume"]) {
+            let volume_in_usd = if let Some(qv) = serde_util::value_as_f64(&item["quoteVolume"]) {
                 qv
             } else {
-                volume * last_price
+                volume * last_price as f64
             };
 
             let daily_price_chg = price_change_percent * 100.0;
@@ -292,7 +292,7 @@ pub(super) async fn fetch_ticker_stats(
             let ticker_stats = TickerStats {
                 mark_price: Price::from_f32(last_price),
                 daily_price_chg,
-                daily_volume: Qty::from_f32_lossy(volume_in_usd),
+                daily_volume: Qty::from_f64(volume_in_usd),
             };
 
             ticker_prices_map.insert(Ticker::new(symbol, exchange), ticker_stats);
@@ -342,13 +342,13 @@ pub(super) async fn fetch_ticker_stats(
             let rise_fall_rate = serde_util::value_as_f32(&item["riseFallRate"])
                 .ok_or_else(|| AdapterError::ParseError("Missing riseFallRate".to_string()))?;
 
-            let volume_24 = serde_util::value_as_f32(&item["volume24"])
+            let volume_24 = serde_util::value_as_f64(&item["volume24"])
                 .ok_or_else(|| AdapterError::ParseError("Missing volume24".to_string()))?;
 
             let volume_in_usd = if perps_market == MarketKind::InversePerps {
-                volume_24 * cs
+                volume_24 * cs as f64
             } else {
-                volume_24 * cs * last_price
+                volume_24 * cs as f64 * last_price as f64
             };
 
             let daily_price_chg = rise_fall_rate * 100.0;
@@ -356,7 +356,7 @@ pub(super) async fn fetch_ticker_stats(
             let ticker_stats = TickerStats {
                 mark_price: Price::from_f32(last_price),
                 daily_price_chg,
-                daily_volume: Qty::from_f32_lossy(volume_in_usd),
+                daily_volume: Qty::from_f64(volume_in_usd),
             };
 
             ticker_prices_map.insert(ticker, ticker_stats);

--- a/exchange/src/adapter/hub/mexc/stream.rs
+++ b/exchange/src/adapter/hub/mexc/stream.rs
@@ -24,9 +24,9 @@ use std::{collections::HashMap, time::Duration};
 #[derive(Deserialize, Debug)]
 struct SonicTrade {
     #[serde(rename = "p")]
-    pub price: f32,
+    pub price: f64,
     #[serde(rename = "v")]
-    pub qty: f32,
+    pub qty: f64,
     #[serde(rename = "T")]
     pub direction: u8,
     #[serde(rename = "t")]
@@ -37,11 +37,11 @@ struct SonicTrade {
 #[derive(Deserialize)]
 struct FuturesDepthItem {
     #[serde()]
-    pub price: f32,
+    pub price: f64,
     #[serde()]
-    pub qty: f32,
+    pub qty: f64,
     #[serde()]
-    pub order_count: f32,
+    pub order_count: f64,
 }
 
 #[derive(Deserialize)]
@@ -59,17 +59,17 @@ struct SonicKline {
     #[serde(rename = "t")]
     time: u64,
     #[serde(rename = "o")]
-    open: f32,
+    open: f64,
     #[serde(rename = "h")]
-    high: f32,
+    high: f64,
     #[serde(rename = "l")]
-    low: f32,
+    low: f64,
     #[serde(rename = "c")]
-    close: f32,
+    close: f64,
     #[serde(rename = "q")]
-    quote_volume: f32,
+    quote_volume: f64,
     #[serde(rename = "a")]
-    _amount: f32,
+    _amount: f64,
     #[serde(rename = "interval")]
     interval: String,
     #[serde(rename = "symbol")]
@@ -539,7 +539,7 @@ pub fn connect_trade_stream(
 
                                                             de_trades.sort_unstable_by_key(|t| t.time);
                                                             for trade in &de_trades {
-                                                                let price = Price::from_f32(trade.price)
+                                                                let price = Price::from_f64(trade.price)
                                                                     .round_to_min_tick(ticker_info.min_ticksize);
 
                                                                 let trade_entity = Trade {

--- a/exchange/src/adapter/hub/okex/fetch.rs
+++ b/exchange/src/adapter/hub/okex/fetch.rs
@@ -114,7 +114,7 @@ pub(super) async fn fetch_ticker_metadata(
                 .ok_or_else(|| AdapterError::ParseError("Tick size not found".to_string()))?;
             let min_qty = serde_util::value_as_f32(&item["lotSz"])
                 .ok_or_else(|| AdapterError::ParseError("Lot size not found".to_string()))?;
-            let contract_size = serde_util::value_as_f64(&item["ctVal"]);
+            let contract_size = serde_util::value_as_f32(&item["ctVal"]);
 
             let ticker = Ticker::new(symbol, exchange);
             let info = TickerInfo::new(ticker, min_ticksize, min_qty, contract_size);

--- a/exchange/src/adapter/hub/okex/fetch.rs
+++ b/exchange/src/adapter/hub/okex/fetch.rs
@@ -159,7 +159,7 @@ pub(super) async fn fetch_ticker_stats(
 
             let last_trade_price = serde_util::value_as_f32(&item["last"]);
             let open24h = serde_util::value_as_f32(&item["open24h"]);
-            let Some(vol24h) = serde_util::value_as_f32(&item["volCcy24h"]) else {
+            let Some(vol24h) = serde_util::value_as_f64(&item["volCcy24h"]) else {
                 continue;
             };
 
@@ -181,7 +181,7 @@ pub(super) async fn fetch_ticker_stats(
                 TickerStats {
                     mark_price: Price::from_f32(last_price),
                     daily_price_chg,
-                    daily_volume: Qty::from_f32_lossy(vol24h),
+                    daily_volume: Qty::from_f64(vol24h),
                 },
             );
         }
@@ -227,7 +227,7 @@ pub(super) async fn fetch_ticker_stats(
             let last_trade_price = serde_util::value_as_f32(&item["last"]);
             let open24h = serde_util::value_as_f32(&item["open24h"]);
 
-            let Some(vol24h) = serde_util::value_as_f32(&item["volCcy24h"]) else {
+            let Some(vol24h) = serde_util::value_as_f64(&item["volCcy24h"]) else {
                 continue;
             };
 
@@ -248,7 +248,7 @@ pub(super) async fn fetch_ticker_stats(
                 TickerStats {
                     mark_price: Price::from_f32(last_price),
                     daily_price_chg,
-                    daily_volume: Qty::from_f32_lossy(vol24h * last_price),
+                    daily_volume: Qty::from_f64(vol24h * last_price as f64),
                 },
             );
         }

--- a/exchange/src/adapter/hub/okex/fetch.rs
+++ b/exchange/src/adapter/hub/okex/fetch.rs
@@ -157,8 +157,8 @@ pub(super) async fn fetch_ticker_stats(
                 continue;
             }
 
-            let last_trade_price = serde_util::value_as_f32(&item["last"]);
-            let open24h = serde_util::value_as_f32(&item["open24h"]);
+            let last_trade_price = serde_util::value_as_f64(&item["last"]);
+            let open24h = serde_util::value_as_f64(&item["open24h"]);
             let Some(vol24h) = serde_util::value_as_f64(&item["volCcy24h"]) else {
                 continue;
             };
@@ -171,7 +171,7 @@ pub(super) async fn fetch_ticker_stats(
                 };
 
             let daily_price_chg = if previous_daily_open > 0.0 {
-                (last_price - previous_daily_open) / previous_daily_open * 100.0
+                ((last_price - previous_daily_open) / previous_daily_open * 100.0) as f32
             } else {
                 0.0
             };
@@ -179,7 +179,7 @@ pub(super) async fn fetch_ticker_stats(
             map.insert(
                 Ticker::new(symbol, exchange),
                 TickerStats {
-                    mark_price: Price::from_f32(last_price),
+                    mark_price: Price::from_f64(last_price),
                     daily_price_chg,
                     daily_volume: Qty::from_f64(vol24h),
                 },
@@ -224,8 +224,8 @@ pub(super) async fn fetch_ticker_stats(
                 continue;
             }
 
-            let last_trade_price = serde_util::value_as_f32(&item["last"]);
-            let open24h = serde_util::value_as_f32(&item["open24h"]);
+            let last_trade_price = serde_util::value_as_f64(&item["last"]);
+            let open24h = serde_util::value_as_f64(&item["open24h"]);
 
             let Some(vol24h) = serde_util::value_as_f64(&item["volCcy24h"]) else {
                 continue;
@@ -238,7 +238,7 @@ pub(super) async fn fetch_ticker_stats(
                     continue;
                 };
             let daily_price_chg = if previous_daily_open > 0.0 {
-                (last_price - previous_daily_open) / previous_daily_open * 100.0
+                ((last_price - previous_daily_open) / previous_daily_open * 100.0) as f32
             } else {
                 0.0
             };
@@ -246,9 +246,9 @@ pub(super) async fn fetch_ticker_stats(
             map.insert(
                 Ticker::new(symbol, exchange),
                 TickerStats {
-                    mark_price: Price::from_f32(last_price),
+                    mark_price: Price::from_f64(last_price),
                     daily_price_chg,
-                    daily_volume: Qty::from_f64(vol24h * last_price as f64),
+                    daily_volume: Qty::from_f64(vol24h * last_price),
                 },
             );
         }

--- a/exchange/src/adapter/hub/okex/fetch.rs
+++ b/exchange/src/adapter/hub/okex/fetch.rs
@@ -181,7 +181,7 @@ pub(super) async fn fetch_ticker_stats(
                 TickerStats {
                     mark_price: Price::from_f32(last_price),
                     daily_price_chg,
-                    daily_volume: Qty::from_f32(vol24h),
+                    daily_volume: Qty::from_f32_lossy(vol24h),
                 },
             );
         }
@@ -248,7 +248,7 @@ pub(super) async fn fetch_ticker_stats(
                 TickerStats {
                     mark_price: Price::from_f32(last_price),
                     daily_price_chg,
-                    daily_volume: Qty::from_f32(vol24h * last_price),
+                    daily_volume: Qty::from_f32_lossy(vol24h * last_price),
                 },
             );
         }

--- a/exchange/src/adapter/hub/okex/fetch.rs
+++ b/exchange/src/adapter/hub/okex/fetch.rs
@@ -114,7 +114,7 @@ pub(super) async fn fetch_ticker_metadata(
                 .ok_or_else(|| AdapterError::ParseError("Tick size not found".to_string()))?;
             let min_qty = serde_util::value_as_f32(&item["lotSz"])
                 .ok_or_else(|| AdapterError::ParseError("Lot size not found".to_string()))?;
-            let contract_size = serde_util::value_as_f32(&item["ctVal"]);
+            let contract_size = serde_util::value_as_f64(&item["ctVal"]);
 
             let ticker = Ticker::new(symbol, exchange);
             let info = TickerInfo::new(ticker, min_ticksize, min_qty, contract_size);
@@ -308,11 +308,11 @@ pub(super) async fn fetch_klines(
 
     for row in list {
         let time = row.get(0).and_then(serde_util::value_as_u64);
-        let open = row.get(1).and_then(serde_util::value_as_f32);
-        let high = row.get(2).and_then(serde_util::value_as_f32);
-        let low = row.get(3).and_then(serde_util::value_as_f32);
-        let close = row.get(4).and_then(serde_util::value_as_f32);
-        let volume = row.get(5).and_then(serde_util::value_as_f32);
+        let open = row.get(1).and_then(serde_util::value_as_f64);
+        let high = row.get(2).and_then(serde_util::value_as_f64);
+        let low = row.get(3).and_then(serde_util::value_as_f64);
+        let close = row.get(4).and_then(serde_util::value_as_f64);
+        let volume = row.get(5).and_then(serde_util::value_as_f64);
 
         let (ts, open, high, low, close) = match (time, open, high, low, close) {
             (Some(ts), Some(o), Some(h), Some(l), Some(c)) => (ts, o, h, l, c),
@@ -374,7 +374,7 @@ pub(super) async fn fetch_historical_oi(
         .filter_map(|row| {
             let arr = row.as_array()?;
             let ts = serde_util::value_as_u64(arr.first()?)?;
-            let oi_ccy = serde_util::value_as_f32(arr.get(2)?)?;
+            let oi_ccy = serde_util::value_as_f64(arr.get(2)?)?;
             Some(OpenInterest {
                 time: ts.into(),
                 value: oi_ccy,

--- a/exchange/src/adapter/hub/okex/stream.rs
+++ b/exchange/src/adapter/hub/okex/stream.rs
@@ -24,9 +24,9 @@ struct SonicTrade {
     #[serde(rename = "ts", deserialize_with = "de_string_to_number")]
     pub time: u64,
     #[serde(rename = "px", deserialize_with = "de_string_to_number")]
-    pub price: f32,
+    pub price: f64,
     #[serde(rename = "sz", deserialize_with = "de_string_to_number")]
-    pub qty: f32,
+    pub qty: f64,
     #[serde(rename = "side")]
     pub is_sell: String,
 }
@@ -373,7 +373,7 @@ pub fn connect_trade_stream(
                                         trades_buffer_map.entry(*ticker).or_default();
 
                                     for de_trade in &de_trade_vec {
-                                        let price = Price::from_f32(de_trade.price)
+                                        let price = Price::from_f64(de_trade.price)
                                             .round_to_min_tick(ticker_info.min_ticksize);
                                         let qty =
                                             qty_norm.normalize_qty(de_trade.qty, de_trade.price);
@@ -513,11 +513,11 @@ pub fn connect_kline_stream(
                                 if let Some(data) = v.get("data").and_then(|d| d.as_array()) {
                                     for row in data {
                                         let time = row.get(0).and_then(serde_util::value_as_u64);
-                                        let open = row.get(1).and_then(serde_util::value_as_f32);
-                                        let high = row.get(2).and_then(serde_util::value_as_f32);
-                                        let low = row.get(3).and_then(serde_util::value_as_f32);
-                                        let close = row.get(4).and_then(serde_util::value_as_f32);
-                                        let volume = row.get(5).and_then(serde_util::value_as_f32);
+                                        let open = row.get(1).and_then(serde_util::value_as_f64);
+                                        let high = row.get(2).and_then(serde_util::value_as_f64);
+                                        let low = row.get(3).and_then(serde_util::value_as_f64);
+                                        let close = row.get(4).and_then(serde_util::value_as_f64);
+                                        let volume = row.get(5).and_then(serde_util::value_as_f64);
 
                                         let (ts, open, high, low, close) =
                                             match (time, open, high, low, close) {

--- a/exchange/src/depth.rs
+++ b/exchange/src/depth.rs
@@ -11,8 +11,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Clone, Copy)]
 pub struct DeOrder {
-    pub price: f32,
-    pub qty: f32,
+    pub price: f64,
+    pub qty: f64,
 }
 
 impl<'de> serde::Deserialize<'de> for DeOrder {
@@ -24,15 +24,15 @@ impl<'de> serde::Deserialize<'de> for DeOrder {
         let value = Value::deserialize(deserializer)?;
 
         let price = match &value {
-            Value::Array(arr) => arr.first().and_then(serde_util::value_as_f32),
-            Value::Object(map) => map.get("0").and_then(serde_util::value_as_f32),
+            Value::Array(arr) => arr.first().and_then(serde_util::value_as_f64),
+            Value::Object(map) => map.get("0").and_then(serde_util::value_as_f64),
             _ => None,
         }
         .ok_or_else(|| SerdeError::custom("Order price not found or invalid"))?;
 
         let qty = match &value {
-            Value::Array(arr) => arr.get(1).and_then(serde_util::value_as_f32),
-            Value::Object(map) => map.get("1").and_then(serde_util::value_as_f32),
+            Value::Array(arr) => arr.get(1).and_then(serde_util::value_as_f64),
+            Value::Object(map) => map.get("1").and_then(serde_util::value_as_f64),
             _ => None,
         }
         .ok_or_else(|| SerdeError::custom("Order qty not found or invalid"))?;
@@ -90,8 +90,8 @@ impl Depth {
                 .map(|normalizer| normalizer.normalize(order.qty, order.price))
                 .unwrap_or(order.qty);
 
-            let price = Price::from_f32(order.price).round_to_min_tick(min_ticksize);
-            let qty = Qty::from_f32(normalized_qty);
+            let price = Price::from_f64(order.price).round_to_min_tick(min_ticksize);
+            let qty = Qty::from_f64(normalized_qty);
 
             if qty.is_zero() {
                 price_map.remove(&price);
@@ -116,8 +116,8 @@ impl Depth {
                     .unwrap_or(de_order.qty);
 
                 (
-                    Price::from_f32(de_order.price).round_to_min_tick(min_ticksize),
-                    Qty::from_f32(normalized_qty),
+                    Price::from_f64(de_order.price).round_to_min_tick(min_ticksize),
+                    Qty::from_f64(normalized_qty),
                 )
             })
             .collect::<BTreeMap<Price, Qty>>();
@@ -130,8 +130,8 @@ impl Depth {
                     .unwrap_or(de_order.qty);
 
                 (
-                    Price::from_f32(de_order.price).round_to_min_tick(min_ticksize),
-                    Qty::from_f32(normalized_qty),
+                    Price::from_f64(de_order.price).round_to_min_tick(min_ticksize),
+                    Qty::from_f64(normalized_qty),
                 )
             })
             .collect::<BTreeMap<Price, Qty>>();

--- a/exchange/src/lib.rs
+++ b/exchange/src/lib.rs
@@ -525,7 +525,7 @@ impl TickerInfo {
         ticker: Ticker,
         min_ticksize: f32,
         min_qty: f32,
-        contract_size: Option<f64>,
+        contract_size: Option<f32>,
     ) -> Self {
         Self {
             ticker,

--- a/exchange/src/lib.rs
+++ b/exchange/src/lib.rs
@@ -525,7 +525,7 @@ impl TickerInfo {
         ticker: Ticker,
         min_ticksize: f32,
         min_qty: f32,
-        contract_size: Option<f32>,
+        contract_size: Option<f64>,
     ) -> Self {
         Self {
             ticker,
@@ -570,10 +570,10 @@ pub struct Kline {
 impl Kline {
     pub fn new(
         time: impl Into<UnixMs>,
-        open: f32,
-        high: f32,
-        low: f32,
-        close: f32,
+        open: f64,
+        high: f64,
+        low: f64,
+        close: f64,
         volume: Volume,
         min_ticksize: MinTicksize,
     ) -> Self {
@@ -581,10 +581,10 @@ impl Kline {
 
         Self {
             time,
-            open: Price::from_f32(open).round_to_min_tick(min_ticksize),
-            high: Price::from_f32(high).round_to_min_tick(min_ticksize),
-            low: Price::from_f32(low).round_to_min_tick(min_ticksize),
-            close: Price::from_f32(close).round_to_min_tick(min_ticksize),
+            open: Price::from_f64(open).round_to_min_tick(min_ticksize),
+            high: Price::from_f64(high).round_to_min_tick(min_ticksize),
+            low: Price::from_f64(low).round_to_min_tick(min_ticksize),
+            close: Price::from_f64(close).round_to_min_tick(min_ticksize),
             volume,
         }
     }
@@ -681,7 +681,7 @@ pub struct TickerStats {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct OpenInterest {
     pub time: UnixMs,
-    pub value: f32,
+    pub value: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash)]

--- a/exchange/src/serde_util.rs
+++ b/exchange/src/serde_util.rs
@@ -13,9 +13,13 @@ where
 }
 
 pub(crate) fn value_as_f32(value: &Value) -> Option<f32> {
+    value_as_f64(value).map(|v| v as f32)
+}
+
+pub(crate) fn value_as_f64(value: &Value) -> Option<f64> {
     match value {
-        Value::String(s) => s.parse::<f32>().ok(),
-        Value::Number(n) => n.as_f64().map(|v| v as f32),
+        Value::String(s) => s.parse::<f64>().ok(),
+        Value::Number(n) => n.as_f64(),
         _ => None,
     }
 }
@@ -33,7 +37,7 @@ pub(crate) fn value_as_u64(value: &Value) -> Option<u64> {
 pub(crate) fn de_number_like_or_object<'de, D, T>(
     deserializer: D,
     expected_name: &'static str,
-    from_f32: impl Fn(f32) -> T,
+    from_f64: impl Fn(f64) -> T,
 ) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
@@ -44,15 +48,14 @@ where
     match value {
         Value::Object(_) => serde_json::from_value::<T>(value).map_err(D::Error::custom),
         Value::String(s) => {
-            let number = s.parse::<f32>().map_err(D::Error::custom)?;
-            Ok(from_f32(number))
+            let number = s.parse::<f64>().map_err(D::Error::custom)?;
+            Ok(from_f64(number))
         }
         Value::Number(n) => {
             let number = n
                 .as_f64()
-                .map(|v| v as f32)
                 .ok_or_else(|| D::Error::custom(format!("expected numeric {expected_name}")))?;
-            Ok(from_f32(number))
+            Ok(from_f64(number))
         }
         _ => Err(D::Error::custom(format!(
             "expected {expected_name} as string or number"

--- a/exchange/src/unit.rs
+++ b/exchange/src/unit.rs
@@ -27,6 +27,11 @@ impl<const MIN: i8, const MAX: i8> Power10<MIN, MAX> {
     pub fn as_f32(self) -> f32 {
         10f32.powi(self.power as i32)
     }
+
+    #[inline]
+    pub fn as_f64(self) -> f64 {
+        10f64.powi(self.power as i32)
+    }
 }
 
 impl<const MIN: i8, const MAX: i8> From<Power10<MIN, MAX>> for f32 {
@@ -37,6 +42,18 @@ impl<const MIN: i8, const MAX: i8> From<Power10<MIN, MAX>> for f32 {
 
 impl<const MIN: i8, const MAX: i8> From<f32> for Power10<MIN, MAX> {
     fn from(value: f32) -> Self {
+        if value <= 0.0 {
+            return Self { power: 0 };
+        }
+        let log10 = value.abs().log10();
+        let rounded = log10.round() as i8;
+        let power = rounded.clamp(MIN, MAX);
+        Self { power }
+    }
+}
+
+impl<const MIN: i8, const MAX: i8> From<f64> for Power10<MIN, MAX> {
+    fn from(value: f64) -> Self {
         if value <= 0.0 {
             return Self { power: 0 };
         }

--- a/exchange/src/unit/price.rs
+++ b/exchange/src/unit/price.rs
@@ -70,15 +70,12 @@ impl Price {
 
     /// Lossy: convert price to f32, may lose precision if going beyond `ATOMIC_SCALE`
     pub fn to_f32_lossy(self) -> f32 {
-        let scale = 10f32.powi(Self::ATOMIC_SCALE);
-        (self.units as f32) / scale
+        self.to_f64() as f32
     }
 
     /// Lossy: create Price from f32 (rounds to nearest atomic unit)
     pub fn from_f32_lossy(v: f32) -> Self {
-        let scale = 10f32.powi(Self::ATOMIC_SCALE);
-        let u = (v * scale).round() as i64;
-        Self { units: u }
+        Self::from_f64(v as f64)
     }
 
     pub fn from_f32(v: f32) -> Self {
@@ -87,6 +84,19 @@ impl Price {
 
     pub fn to_f32(self) -> f32 {
         self.to_f32_lossy()
+    }
+
+    /// Convert price to f64.  f64 has ~15 significant digits.
+    pub fn to_f64(self) -> f64 {
+        let scale = 10f64.powi(Self::ATOMIC_SCALE);
+        (self.units as f64) / scale
+    }
+
+    /// Create Price from f64 (rounds to nearest atomic unit).
+    pub fn from_f64(v: f64) -> Self {
+        let scale = 10f64.powi(Self::ATOMIC_SCALE);
+        let u = (v * scale).round() as i64;
+        Self { units: u }
     }
 
     pub fn round_to_step(self, step: PriceStep) -> Self {
@@ -219,7 +229,7 @@ pub fn de_price_from_number<'de, D>(deserializer: D) -> Result<Price, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    serde_util::de_number_like_or_object(deserializer, "price", Price::from_f32)
+    serde_util::de_number_like_or_object(deserializer, "price", Price::from_f64)
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -276,21 +286,31 @@ impl PriceStep {
 
     /// Lossy: f32 step for UI
     pub fn to_f32_lossy(self) -> f32 {
-        let scale = 10f32.powi(Price::ATOMIC_SCALE);
-        (self.units as f32) / scale
+        self.to_f64_lossy() as f32
     }
 
     /// Lossy: from f32 step (rounds to nearest atomic unit)
     pub fn from_f32_lossy(step: f32) -> Self {
-        assert!(step > 0.0, "step must be > 0");
-        let scale = 10f32.powi(Price::ATOMIC_SCALE);
-        let units = (step * scale).round() as i64;
-        assert!(units > 0, "step too small at given ATOMIC_SCALE");
-        Self { units }
+        Self::from_f64_lossy(step as f64)
     }
 
     pub fn from_f32(step: f32) -> Self {
         Self::from_f32_lossy(step)
+    }
+
+    /// f64 step for UI
+    pub fn to_f64_lossy(self) -> f64 {
+        let scale = 10f64.powi(Price::ATOMIC_SCALE);
+        (self.units as f64) / scale
+    }
+
+    /// from f64 step (rounds to nearest atomic unit)
+    pub fn from_f64_lossy(step: f64) -> Self {
+        assert!(step > 0.0, "step must be > 0");
+        let scale = 10f64.powi(Price::ATOMIC_SCALE);
+        let units = (step * scale).round() as i64;
+        assert!(units > 0, "step too small at given ATOMIC_SCALE");
+        Self { units }
     }
 }
 

--- a/exchange/src/unit/price.rs
+++ b/exchange/src/unit/price.rs
@@ -291,24 +291,10 @@ impl PriceStep {
         self.to_f64_lossy() as f32
     }
 
-    /// from f32 step (widens to f64, then rounds to nearest atomic unit)
-    pub fn from_f32(step: f32) -> Self {
-        Self::from_f64_lossy(step as f64)
-    }
-
     /// f64 step for UI
     pub fn to_f64_lossy(self) -> f64 {
         let scale = 10f64.powi(Price::ATOMIC_SCALE);
         (self.units as f64) / scale
-    }
-
-    /// from f64 step (rounds to nearest atomic unit)
-    pub fn from_f64_lossy(step: f64) -> Self {
-        assert!(step > 0.0, "step must be > 0");
-        let scale = 10f64.powi(Price::ATOMIC_SCALE);
-        let units = (step * scale).round() as i64;
-        assert!(units > 0, "step too small at given ATOMIC_SCALE");
-        Self { units }
     }
 }
 

--- a/exchange/src/unit/price.rs
+++ b/exchange/src/unit/price.rs
@@ -73,17 +73,9 @@ impl Price {
         self.to_f64() as f32
     }
 
-    /// Lossy: create Price from f32 (rounds to nearest atomic unit)
-    pub fn from_f32_lossy(v: f32) -> Self {
-        Self::from_f64(v as f64)
-    }
-
+    /// Create Price from f32 (widens to f64, then rounds to nearest atomic unit)
     pub fn from_f32(v: f32) -> Self {
-        Self::from_f32_lossy(v)
-    }
-
-    pub fn to_f32(self) -> f32 {
-        self.to_f32_lossy()
+        Self::from_f64(v as f64)
     }
 
     /// Convert price to f64.  f64 has ~15 significant digits.
@@ -212,6 +204,16 @@ impl std::ops::Div<i64> for Price {
     }
 }
 
+impl std::ops::Div for Price {
+    type Output = f64;
+
+    /// Ratio of two prices as a dimensionless f64.
+    /// Both sides share the same atomic scale so this is exact.
+    fn div(self, rhs: Self) -> f64 {
+        self.units as f64 / rhs.units as f64
+    }
+}
+
 impl std::ops::Sub for Price {
     type Output = Self;
 
@@ -289,13 +291,9 @@ impl PriceStep {
         self.to_f64_lossy() as f32
     }
 
-    /// Lossy: from f32 step (rounds to nearest atomic unit)
-    pub fn from_f32_lossy(step: f32) -> Self {
-        Self::from_f64_lossy(step as f64)
-    }
-
+    /// from f32 step (widens to f64, then rounds to nearest atomic unit)
     pub fn from_f32(step: f32) -> Self {
-        Self::from_f32_lossy(step)
+        Self::from_f64_lossy(step as f64)
     }
 
     /// f64 step for UI

--- a/exchange/src/unit/qty.rs
+++ b/exchange/src/unit/qty.rs
@@ -53,11 +53,6 @@ impl Qty {
         self.to_f64() as f32
     }
 
-    /// Lossy: create Qty from f32 (rounds to nearest atomic unit)
-    pub fn from_f32_lossy(v: f32) -> Self {
-        Self::from_f64(v as f64)
-    }
-
     pub fn to_f64(self) -> f64 {
         let scale = 10f64.powi(Self::QTY_SCALE);
         (self.units as f64) / scale

--- a/exchange/src/unit/qty.rs
+++ b/exchange/src/unit/qty.rs
@@ -48,10 +48,6 @@ impl Qty {
     pub const QTY_SCALE: i32 = 8;
     pub const ZERO: Self = Self { units: 0 };
 
-    pub const fn zero() -> Self {
-        Self::ZERO
-    }
-
     /// Lossy: convert qty to f32, may lose precision beyond `QTY_SCALE`
     pub fn to_f32_lossy(self) -> f32 {
         self.to_f64() as f32
@@ -62,12 +58,6 @@ impl Qty {
         Self::from_f64(v as f64)
     }
 
-    pub fn from_f32(v: f32) -> Self {
-        Self::from_f32_lossy(v)
-    }
-
-    /// Convert qty to f64.  f64 has ~15 significant digits, enough for
-    /// any practical cumulative volume without visible drift.
     pub fn to_f64(self) -> f64 {
         let scale = 10f64.powi(Self::QTY_SCALE);
         (self.units as f64) / scale
@@ -150,18 +140,6 @@ impl Qty {
 
     pub const fn is_zero(self) -> bool {
         self.units == 0
-    }
-}
-
-impl From<Qty> for f32 {
-    fn from(value: Qty) -> Self {
-        value.to_f32_lossy()
-    }
-}
-
-impl From<f32> for Qty {
-    fn from(value: f32) -> Self {
-        Qty::from_f32(value)
     }
 }
 

--- a/exchange/src/unit/qty.rs
+++ b/exchange/src/unit/qty.rs
@@ -54,19 +54,30 @@ impl Qty {
 
     /// Lossy: convert qty to f32, may lose precision beyond `QTY_SCALE`
     pub fn to_f32_lossy(self) -> f32 {
-        let scale = 10f32.powi(Self::QTY_SCALE);
-        (self.units as f32) / scale
+        self.to_f64() as f32
     }
 
     /// Lossy: create Qty from f32 (rounds to nearest atomic unit)
     pub fn from_f32_lossy(v: f32) -> Self {
-        let scale = 10f32.powi(Self::QTY_SCALE);
-        let units = (v * scale).round() as i64;
-        Self { units }
+        Self::from_f64(v as f64)
     }
 
     pub fn from_f32(v: f32) -> Self {
         Self::from_f32_lossy(v)
+    }
+
+    /// Convert qty to f64.  f64 has ~15 significant digits, enough for
+    /// any practical cumulative volume without visible drift.
+    pub fn to_f64(self) -> f64 {
+        let scale = 10f64.powi(Self::QTY_SCALE);
+        (self.units as f64) / scale
+    }
+
+    /// Create Qty from f64 (rounds to nearest atomic unit).
+    pub fn from_f64(v: f64) -> Self {
+        let scale = 10f64.powi(Self::QTY_SCALE);
+        let units = (v * scale).round() as i64;
+        Self { units }
     }
 
     pub const fn from_units(units: i64) -> Self {
@@ -90,13 +101,13 @@ impl Qty {
     }
 
     /// Guards scale/denominator values against zero-ish inputs.
-    pub fn scale_or_one(v: f32) -> f32 {
-        if v <= f32::EPSILON { 1.0 } else { v }
+    pub fn scale_or_one(v: f64) -> f64 {
+        if v <= f64::EPSILON { 1.0 } else { v }
     }
 
-    /// Converts to f32 and applies `scale_or_one`.
-    pub fn to_scale_or_one(self) -> f32 {
-        Self::scale_or_one(self.to_f32_lossy())
+    /// Converts to f64 and applies `scale_or_one`.
+    pub fn to_scale_or_one(self) -> f64 {
+        Self::scale_or_one(self.to_f64())
     }
 
     fn min_qty_units(min_qty: MinQtySize) -> i64 {
@@ -154,6 +165,18 @@ impl From<f32> for Qty {
     }
 }
 
+impl From<Qty> for f64 {
+    fn from(value: Qty) -> Self {
+        value.to_f64()
+    }
+}
+
+impl From<f64> for Qty {
+    fn from(value: f64) -> Self {
+        Qty::from_f64(value)
+    }
+}
+
 impl std::ops::Add for Qty {
     type Output = Self;
 
@@ -201,7 +224,7 @@ impl std::ops::SubAssign for Qty {
 #[derive(Debug, Clone, Copy)]
 pub struct QtyNormalization {
     size_in_quote_ccy: bool,
-    contract_size: Option<f32>,
+    contract_size: Option<f64>,
     market_kind: MarketKind,
     raw_qty_unit: Option<RawQtyUnit>,
 }
@@ -221,7 +244,7 @@ impl QtyNormalization {
     pub fn new(size_in_quote_ccy: bool, ticker: TickerInfo) -> Self {
         let market_kind = ticker.exchange().market_type();
 
-        let contract_size = ticker.contract_size.map(|cs| cs.as_f32()).or({
+        let contract_size = ticker.contract_size.map(|cs| cs.as_f64()).or({
             if matches!(market_kind, MarketKind::InversePerps) {
                 Some(1.0)
             } else {
@@ -247,7 +270,7 @@ impl QtyNormalization {
         normalizer
     }
 
-    fn normalize_with_raw_unit(self, qty: f32, price: f32, raw_qty_unit: RawQtyUnit) -> f32 {
+    fn normalize_with_raw_unit(self, qty: f64, price: f64, raw_qty_unit: RawQtyUnit) -> f64 {
         let safe_price = Qty::scale_or_one(price);
 
         let (base_qty, quote_qty) = match raw_qty_unit {
@@ -273,7 +296,7 @@ impl QtyNormalization {
         }
     }
 
-    pub fn normalize(self, qty: f32, price: f32) -> f32 {
+    pub fn normalize(self, qty: f64, price: f64) -> f64 {
         if let Some(raw_qty_unit) = self.raw_qty_unit {
             return self.normalize_with_raw_unit(qty, price, raw_qty_unit);
         }
@@ -304,8 +327,8 @@ impl QtyNormalization {
         }
     }
 
-    pub fn normalize_qty(self, qty: f32, price: f32) -> Qty {
-        Qty::from_f32(self.normalize(qty, price))
+    pub fn normalize_qty(self, qty: f64, price: f64) -> Qty {
+        Qty::from_f64(self.normalize(qty, price))
     }
 }
 
@@ -313,5 +336,5 @@ pub fn de_qty_from_number<'de, D>(deserializer: D) -> Result<Qty, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    serde_util::de_number_like_or_object(deserializer, "qty", Qty::from_f32)
+    serde_util::de_number_like_or_object(deserializer, "qty", Qty::from_f64)
 }

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -681,7 +681,7 @@ impl ViewState {
             cell_height,
             basis,
             last_price: None,
-            base_price_y: Price::from_f32_lossy(0.0),
+            base_price_y: Price::from_f32(0.0),
             latest_x: 0,
             tick_size,
             decimals,
@@ -816,7 +816,7 @@ impl ViewState {
                 let ratio = y / bounds.height;
                 let price = highest + ratio * (lowest - highest);
 
-                let p = Price::from_f32_lossy(price);
+                let p = Price::from_f32(price);
                 let tick_units = effective_step.units;
                 let tick_index = p.units.div_euclid(tick_units);
                 let rounded_price_p = Price::from_units(tick_index * tick_units);
@@ -980,7 +980,7 @@ impl ViewState {
         let crosshair_ratio = cursor_position.y / bounds.height;
         let crosshair_price = highest + crosshair_ratio * (lowest - highest);
 
-        let rounded_price = Price::from_f32_lossy(crosshair_price)
+        let rounded_price = Price::from_f32(crosshair_price)
             .round_to_step(effective_step)
             .to_f32_lossy();
         let snap_ratio = (rounded_price - highest) / (lowest - highest);
@@ -1145,9 +1145,9 @@ fn draw_volume_bar(
     frame: &mut canvas::Frame,
     start_x: f32,
     start_y: f32,
-    buy_qty: f32,
-    sell_qty: f32,
-    max_qty: f32,
+    buy_qty: f64,
+    sell_qty: f64,
+    max_qty: f64,
     bar_length: f32,
     thickness: f32,
     buy_color: iced::Color,
@@ -1160,10 +1160,10 @@ fn draw_volume_bar(
         return;
     }
 
-    let total_bar_length = (total_qty / max_qty) * bar_length;
+    let total_bar_length = (total_qty / max_qty) as f32 * bar_length;
 
-    let buy_proportion = buy_qty / total_qty;
-    let sell_proportion = sell_qty / total_qty;
+    let buy_proportion = (buy_qty / total_qty) as f32;
+    let sell_proportion = (sell_qty / total_qty) as f32;
 
     let buy_bar_length = buy_proportion * total_bar_length;
     let sell_bar_length = sell_proportion * total_bar_length;

--- a/src/chart/comparison.rs
+++ b/src/chart/comparison.rs
@@ -144,7 +144,7 @@ impl ComparisonChart {
         let timeframe = self.timeframe;
         let mut incoming: Vec<(u64, f32)> = klines
             .iter()
-            .map(|k| (k.time.floor_to(timeframe).as_u64(), k.close.to_f32()))
+            .map(|k| (k.time.floor_to(timeframe).as_u64(), k.close.to_f32_lossy()))
             .collect();
 
         let idx = self.get_or_create_series_idx(&ticker_info);
@@ -212,7 +212,7 @@ impl ComparisonChart {
         let series = &mut self.series[idx];
 
         // Align to timeframe grid
-        let new_point = (t, kline.close.to_f32());
+        let new_point = (t, kline.close.to_f32_lossy());
 
         if let Some((last_x, last_y)) = series.points.last_mut() {
             if *last_x == new_point.0 {

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -541,7 +541,7 @@ impl canvas::Program<Message> for HeatmapChart {
                                     *price,
                                     size_in_quote_ccy,
                                 );
-                                order_size > self.visual_config.order_size_filter
+                                order_size as f32 > self.visual_config.order_size_filter
                             })
                             .for_each(|run| {
                                 let start_x = chart.interval_to_x(
@@ -637,7 +637,7 @@ impl canvas::Program<Message> for HeatmapChart {
                             size_in_quote_ccy,
                         );
 
-                        if trade_size > self.visual_config.trade_size_filter {
+                        if trade_size as f32 > self.visual_config.trade_size_filter {
                             let color = if trade.is_sell {
                                 palette.danger.base.color
                             } else {

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -601,7 +601,7 @@ impl canvas::Program<Message> for HeatmapChart {
 
                     // max bid/ask quantity text
                     let text_size = crate::style::text_size::TINY / chart.scaling;
-                    let text_content = abbr_large_numbers(max_qty);
+                    let text_content = abbr_large_numbers(max_qty as f64);
 
                     let text_position = Point::new(
                         current_depth_area_width,
@@ -688,7 +688,7 @@ impl canvas::Program<Message> for HeatmapChart {
 
             if volume_indicator && max_aggr_volume > 0.0 {
                 let text_size = crate::style::text_size::TINY / chart.scaling;
-                let text_content = abbr_large_numbers(max_aggr_volume);
+                let text_content = abbr_large_numbers(max_aggr_volume as f64);
 
                 let text_position = Point::new(
                     region.x + region.width - 4.0,
@@ -866,7 +866,7 @@ impl canvas::Program<Message> for HeatmapChart {
                             if let Some((qty, is_bid)) =
                                 display_grid_qtys.get(&(data_time_val, data_price_key))
                             {
-                                let text_content = abbr_large_numbers(qty.to_f32_lossy());
+                                let text_content = abbr_large_numbers(qty.to_f64());
                                 let color = if *is_bid {
                                     palette.success.strong.color
                                 } else {
@@ -1040,7 +1040,7 @@ fn draw_volume_profile(
 
     if max_aggr_volume > 0.0 {
         let text_size = crate::style::text_size::TINY / chart.scaling;
-        let text_content = abbr_large_numbers(max_aggr_volume);
+        let text_content = abbr_large_numbers(max_aggr_volume as f64);
 
         let text_position = Point::new(region.x + area_width, region.y);
 

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -629,7 +629,7 @@ impl canvas::Program<Message> for HeatmapChart {
 
                     dp.grouped_trades.iter().for_each(|trade| {
                         let y_position = chart.price_to_y(trade.price);
-                        let trade_qty = f32::from(trade.qty);
+                        let trade_qty = trade.qty.to_f32_lossy();
 
                         let trade_size = market_type.qty_in_quote_value(
                             trade.qty,
@@ -673,8 +673,8 @@ impl canvas::Program<Message> for HeatmapChart {
                             frame,
                             x_position,
                             (region.y + region.height) - area_height,
-                            f32::from(buy_volume),
-                            f32::from(sell_volume),
+                            buy_volume.to_f32_lossy(),
+                            sell_volume.to_f32_lossy(),
                             max_aggr_volume,
                             area_height,
                             bar_width,
@@ -998,7 +998,7 @@ fn draw_volume_profile(
                     let index = ((grouped_price.units - first_tick.units) / step.units) as usize;
 
                     if let Some(entry) = profile.get_mut(index) {
-                        let trade_qty = f32::from(trade.qty);
+                        let trade_qty = trade.qty.to_f32_lossy();
                         if trade.is_sell {
                             entry.1 += trade_qty;
                         } else {

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -482,9 +482,9 @@ impl canvas::Program<Message> for HeatmapChart {
             let cell_height = chart.cell_height;
             let qty_scales = self.calc_qty_scales(earliest, latest, highest, lowest);
 
-            let max_depth_qty = qty_scales.max_depth_qty.to_f32_lossy();
-            let max_aggr_volume = qty_scales.max_aggr_volume.to_f32_lossy();
-            let max_trade_qty = qty_scales.max_trade_qty.to_f32_lossy();
+            let max_depth_qty = qty_scales.max_depth_qty.to_f64();
+            let max_aggr_volume = qty_scales.max_aggr_volume.to_f64();
+            let max_trade_qty = qty_scales.max_trade_qty.to_f64();
 
             let size_in_quote_ccy = volume_size_unit() == SizeUnit::Quote;
 
@@ -519,7 +519,7 @@ impl canvas::Program<Message> for HeatmapChart {
                     let width = end_x - start_x;
 
                     if width > 0.001 {
-                        let color_alpha = (visual_run.qty.to_f32_lossy() / max_depth_qty).min(1.0);
+                        let color_alpha = (visual_run.qty.to_f64() / max_depth_qty).min(1.0) as f32;
 
                         frame.fill_rectangle(
                             Point::new(start_x, y_position - (cell_height / 2.0)),
@@ -553,7 +553,8 @@ impl canvas::Program<Message> for HeatmapChart {
 
                                 let width = end_x - start_x;
 
-                                let color_alpha = (run.qty.to_f32_lossy() / max_depth_qty).min(1.0);
+                                let color_alpha =
+                                    (run.qty.to_f64() / max_depth_qty).min(1.0) as f32;
 
                                 frame.fill_rectangle(
                                     Point::new(start_x, y_position - (cell_height / 2.0)),
@@ -629,7 +630,7 @@ impl canvas::Program<Message> for HeatmapChart {
 
                     dp.grouped_trades.iter().for_each(|trade| {
                         let y_position = chart.price_to_y(trade.price);
-                        let trade_qty = trade.qty.to_f32_lossy();
+                        let trade_qty = trade.qty.to_f64();
 
                         let trade_size = market_type.qty_in_quote_value(
                             trade.qty,
@@ -648,7 +649,7 @@ impl canvas::Program<Message> for HeatmapChart {
                                 if let Some(trade_size_scale) = self.visual_config.trade_size_scale
                                 {
                                     let scale_factor = (trade_size_scale as f32) / 100.0;
-                                    1.0 + (trade_qty / max_trade_qty)
+                                    1.0 + (trade_qty / max_trade_qty) as f32
                                         * (MAX_CIRCLE_RADIUS - 1.0)
                                         * scale_factor
                                 } else {
@@ -673,8 +674,8 @@ impl canvas::Program<Message> for HeatmapChart {
                             frame,
                             x_position,
                             (region.y + region.height) - area_height,
-                            buy_volume.to_f32_lossy(),
-                            sell_volume.to_f32_lossy(),
+                            buy_volume.to_f64(),
+                            sell_volume.to_f64(),
                             max_aggr_volume,
                             area_height,
                             bar_width,
@@ -688,7 +689,7 @@ impl canvas::Program<Message> for HeatmapChart {
 
             if volume_indicator && max_aggr_volume > 0.0 {
                 let text_size = crate::style::text_size::TINY / chart.scaling;
-                let text_content = abbr_large_numbers(max_aggr_volume as f64);
+                let text_content = abbr_large_numbers(max_aggr_volume);
 
                 let text_position = Point::new(
                     region.x + region.width - 4.0,
@@ -976,8 +977,8 @@ fn draw_volume_profile(
         return;
     }
 
-    let mut profile = vec![(0.0f32, 0.0f32); num_ticks];
-    let mut max_aggr_volume = 0.0f32;
+    let mut profile = vec![(0.0f64, 0.0f64); num_ticks];
+    let mut max_aggr_volume = 0.0f64;
 
     timeseries
         .datapoints
@@ -998,7 +999,7 @@ fn draw_volume_profile(
                     let index = ((grouped_price.units - first_tick.units) / step.units) as usize;
 
                     if let Some(entry) = profile.get_mut(index) {
-                        let trade_qty = trade.qty.to_f32_lossy();
+                        let trade_qty = trade.qty.to_f64();
                         if trade.is_sell {
                             entry.1 += trade_qty;
                         } else {
@@ -1040,7 +1041,7 @@ fn draw_volume_profile(
 
     if max_aggr_volume > 0.0 {
         let text_size = crate::style::text_size::TINY / chart.scaling;
-        let text_content = abbr_large_numbers(max_aggr_volume as f64);
+        let text_content = abbr_large_numbers(max_aggr_volume);
 
         let text_position = Point::new(region.x + area_width, region.y);
 

--- a/src/chart/indicator.rs
+++ b/src/chart/indicator.rs
@@ -169,7 +169,7 @@ impl canvas::Program<Message> for IndicatorLabel<'_> {
                 );
 
                 let label = LabelContent {
-                    content: abbr_large_numbers(rounded_value),
+                    content: abbr_large_numbers(rounded_value as f64),
                     background_color: Some(palette.secondary.base.color),
                     text_color: palette.secondary.base.text,
                     text_size: TEXT_SIZE,

--- a/src/chart/indicator/kline/cumulative_delta.rs
+++ b/src/chart/indicator/kline/cumulative_delta.rs
@@ -68,19 +68,13 @@ impl CumulativeDeltaIndicator {
         }
 
         let tooltip = |point: &CumulativeDeltaPoint, _next: Option<&CumulativeDeltaPoint>| {
-            let cvd = format!(
-                "CVD: {}",
-                format_with_commas(point.cumulative.to_f32_lossy())
-            );
+            let cvd = format!("CVD: {}", format_with_commas(point.cumulative.to_f64()));
             let sign = if point.delta >= Qty::ZERO { "+" } else { "" };
-            let delta = format!(
-                "Delta: {sign}{}",
-                format_with_commas(point.delta.to_f32_lossy())
-            );
+            let delta = format!("Delta: {sign}{}", format_with_commas(point.delta.to_f64()));
             PlotTooltip::new(format!("{cvd}\n{delta}"))
         };
 
-        let value_fn = |point: &CumulativeDeltaPoint| point.cumulative.to_f32_lossy();
+        let value_fn = |point: &CumulativeDeltaPoint| point.cumulative.to_f64() as f32;
 
         let plot = LinePlot::new(value_fn)
             .stroke_width(1.0)

--- a/src/chart/indicator/kline/open_interest.rs
+++ b/src/chart/indicator/kline/open_interest.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeMap, ops::RangeInclusive};
 
 pub struct OpenInterestIndicator {
     cache: Caches,
-    pub data: BTreeMap<UnixMs, f32>,
+    pub data: BTreeMap<UnixMs, f64>,
 }
 
 impl OpenInterestIndicator {
@@ -44,7 +44,7 @@ impl OpenInterestIndicator {
             return row![].into();
         }
 
-        let tooltip = |value: &f32, next: Option<&f32>| {
+        let tooltip = |value: &f64, next: Option<&f64>| {
             let value_text = format!("Open Interest: {}", format_with_commas(*value));
             let change_text = if let Some(next_value) = next {
                 let delta = next_value - *value;
@@ -56,7 +56,7 @@ impl OpenInterestIndicator {
             PlotTooltip::new(format!("{value_text}\n{change_text}"))
         };
 
-        let value_fn = |v: &f32| *v;
+        let value_fn = |v: &f64| *v as f32;
 
         let plot = LinePlot::new(value_fn)
             .stroke_width(1.0)

--- a/src/chart/indicator/kline/volume.rs
+++ b/src/chart/indicator/kline/volume.rs
@@ -37,13 +37,13 @@ impl VolumeIndicator {
     ) -> iced::Element<'a, Message> {
         let tooltip = |volume: &Volume, _next: Option<&Volume>| {
             if let Some((buy, sell)) = volume.buy_sell() {
-                let buy_t = format!("Buy Volume: {}", format_with_commas(f32::from(buy)));
-                let sell_t = format!("Sell Volume: {}", format_with_commas(f32::from(sell)));
+                let buy_t = format!("Buy Volume: {}", format_with_commas(f64::from(buy)));
+                let sell_t = format!("Sell Volume: {}", format_with_commas(f64::from(sell)));
                 PlotTooltip::new(format!("{buy_t}\n{sell_t}"))
             } else {
                 PlotTooltip::new(format!(
                     "Volume: {}",
-                    format_with_commas(f32::from(volume.total()))
+                    format_with_commas(f64::from(volume.total()))
                 ))
             }
         };

--- a/src/chart/indicator/kline/volume.rs
+++ b/src/chart/indicator/kline/volume.rs
@@ -51,14 +51,14 @@ impl VolumeIndicator {
         let bar_kind = |volume: &Volume| {
             if let Some((buy, sell)) = volume.buy_sell() {
                 BarClass::Overlay {
-                    overlay: f32::from(buy) - f32::from(sell),
+                    overlay: buy.to_f32_lossy() - sell.to_f32_lossy(),
                 }
             } else {
                 BarClass::Single
             }
         };
 
-        let value_fn = |volume: &Volume| f32::from(volume.total());
+        let value_fn = |volume: &Volume| volume.total().to_f32_lossy();
 
         let plot = BarPlot::new(value_fn, bar_kind)
             .bar_width_factor(0.9)

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1422,11 +1422,11 @@ fn effective_cluster_qty(
     let individual_max_f32 = f32::from(individual_max);
 
     match scaling {
-        ClusterScaling::VisibleRange => Qty::scale_or_one(visible_max),
-        ClusterScaling::Datapoint => individual_max.to_scale_or_one(),
+        ClusterScaling::VisibleRange => Qty::scale_or_one(visible_max as f64) as f32,
+        ClusterScaling::Datapoint => individual_max.to_scale_or_one() as f32,
         ClusterScaling::Hybrid { weight } => {
             let w = weight.clamp(0.0, 1.0);
-            Qty::scale_or_one(visible_max * w + individual_max_f32 * (1.0 - w))
+            Qty::scale_or_one((visible_max * w + individual_max_f32 * (1.0 - w)) as f64) as f32
         }
     }
 }
@@ -1494,7 +1494,7 @@ fn draw_clusters(
                         if show_text {
                             draw_cluster_text(
                                 frame,
-                                &abbr_large_numbers(f32::from(group.total_qty())),
+                                &abbr_large_numbers(f64::from(group.total_qty())),
                                 Point::new(area.bars_left, y),
                                 text_size,
                                 text_color,
@@ -1508,7 +1508,7 @@ fn draw_clusters(
                         if show_text {
                             draw_cluster_text(
                                 frame,
-                                &abbr_large_numbers(delta),
+                                &abbr_large_numbers(delta as f64),
                                 Point::new(area.bars_left, y),
                                 text_size,
                                 text_color,
@@ -1605,7 +1605,7 @@ fn draw_clusters(
                     if show_text {
                         draw_cluster_text(
                             frame,
-                            &abbr_large_numbers(buy_qty),
+                            &abbr_large_numbers(buy_qty as f64),
                             Point::new(area.bid_area_left, y),
                             text_size,
                             text_color,
@@ -1627,7 +1627,7 @@ fn draw_clusters(
                     if show_text {
                         draw_cluster_text(
                             frame,
-                            &abbr_large_numbers(sell_qty),
+                            &abbr_large_numbers(sell_qty as f64),
                             Point::new(area.ask_area_right, y),
                             text_size,
                             text_color,
@@ -1705,7 +1705,7 @@ fn draw_clusters(
 
         draw_cluster_text(
             frame,
-            &format!("V: {}", abbr_large_numbers(total_vol.to_f32_lossy())),
+            &format!("V: {}", abbr_large_numbers(total_vol.to_f64())),
             Point::new(x_position, summary_y),
             text_size * 0.9,
             palette.background.weakest.text,
@@ -1721,7 +1721,7 @@ fn draw_clusters(
 
         draw_cluster_text(
             frame,
-            &format!("Δ: {}", abbr_large_numbers(total_delta.to_f32_lossy())),
+            &format!("Δ: {}", abbr_large_numbers(total_delta.to_f64())),
             Point::new(x_position, summary_y + line_spacing),
             text_size * 0.9,
             delta_color,

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -712,7 +712,7 @@ impl KlineChart {
         lowest: Price,
         step: PriceStep,
         cluster_kind: ClusterKind,
-    ) -> f32 {
+    ) -> f64 {
         let rounded_highest = highest.round_to_side_step(false, step).add_steps(1, step);
         let rounded_lowest = lowest.round_to_side_step(true, step).add_steps(-1, step);
 
@@ -725,7 +725,7 @@ impl KlineChart {
                     rounded_highest,
                     rounded_lowest,
                 )
-                .to_f32_lossy(),
+                .to_f64(),
             PlotData::TickBased(tick_aggr) => {
                 let earliest = earliest as usize;
                 let latest = latest as usize;
@@ -738,7 +738,7 @@ impl KlineChart {
                         rounded_highest,
                         rounded_lowest,
                     )
-                    .to_f32_lossy()
+                    .to_f64()
             }
         }
     }
@@ -1395,10 +1395,10 @@ fn draw_all_npocs(
 
 fn effective_cluster_qty(
     scaling: ClusterScaling,
-    visible_max: f32,
+    visible_max: f64,
     footprint: &KlineTrades,
     cluster_kind: ClusterKind,
-) -> f32 {
+) -> f64 {
     let individual_max = match cluster_kind {
         ClusterKind::BidAsk => footprint
             .trades
@@ -1419,14 +1419,13 @@ fn effective_cluster_qty(
             .max()
             .unwrap_or_default(),
     };
-    let individual_max_f32 = individual_max.to_f32_lossy();
 
     match scaling {
-        ClusterScaling::VisibleRange => Qty::scale_or_one(visible_max as f64) as f32,
-        ClusterScaling::Datapoint => individual_max.to_scale_or_one() as f32,
+        ClusterScaling::VisibleRange => Qty::scale_or_one(visible_max),
+        ClusterScaling::Datapoint => individual_max.to_scale_or_one(),
         ClusterScaling::Hybrid { weight } => {
-            let w = weight.clamp(0.0, 1.0);
-            Qty::scale_or_one((visible_max * w + individual_max_f32 * (1.0 - w)) as f64) as f32
+            let w = weight.clamp(0.0, 1.0) as f64;
+            Qty::scale_or_one(visible_max * w + individual_max.to_f64() * (1.0 - w))
         }
     }
 }
@@ -1438,7 +1437,7 @@ fn draw_clusters(
     cell_width: f32,
     cell_height: f32,
     candle_width: f32,
-    max_cluster_qty: f32,
+    max_cluster_qty: f64,
     palette: &Extended,
     text_size: f32,
     step: PriceStep,
@@ -1470,8 +1469,8 @@ fn draw_clusters(
             let bar_alpha = if show_text { 0.25 } else { 1.0 };
 
             for (price, group) in &footprint.trades {
-                let buy_qty = group.buy_qty.to_f32_lossy();
-                let sell_qty = group.sell_qty.to_f32_lossy();
+                let buy_qty = group.buy_qty.to_f64();
+                let sell_qty = group.sell_qty.to_f64();
                 let y = price_to_y(*price);
 
                 match cluster_kind {
@@ -1504,11 +1503,11 @@ fn draw_clusters(
                         }
                     }
                     ClusterKind::DeltaProfile => {
-                        let delta = group.delta_qty().to_f32_lossy();
+                        let delta = group.delta_qty().to_f64();
                         if show_text {
                             draw_cluster_text(
                                 frame,
-                                &abbr_large_numbers(delta as f64),
+                                &abbr_large_numbers(delta),
                                 Point::new(area.bars_left, y),
                                 text_size,
                                 text_color,
@@ -1517,7 +1516,7 @@ fn draw_clusters(
                             );
                         }
 
-                        let bar_width = (delta.abs() / max_cluster_qty) * area.bars_width;
+                        let bar_width = (delta.abs() / max_cluster_qty) as f32 * area.bars_width;
                         if bar_width > 0.0 {
                             let color = if delta >= 0.0 {
                                 palette.success.base.color.scale_alpha(bar_alpha)
@@ -1535,8 +1534,7 @@ fn draw_clusters(
                 }
 
                 if let Some((threshold, color_scale, ignore_zeros)) = imbalance {
-                    let higher_price =
-                        Price::from_f32(price.to_f32() + step.to_f32_lossy()).round_to_step(step);
+                    let higher_price = price.add_steps(1, step);
 
                     let rect_w = ((area.imb_marker_width - 1.0) / 2.0).max(1.0);
                     let buyside_x = area.imb_marker_left + area.imb_marker_width - rect_w;
@@ -1597,15 +1595,15 @@ fn draw_clusters(
             let left_area_width = (area.ask_area_right - left_min_x).max(0.0);
 
             for (price, group) in &footprint.trades {
-                let buy_qty = group.buy_qty.to_f32_lossy();
-                let sell_qty = group.sell_qty.to_f32_lossy();
+                let buy_qty = group.buy_qty.to_f64();
+                let sell_qty = group.sell_qty.to_f64();
                 let y = price_to_y(*price);
 
                 if buy_qty > 0.0 && right_area_width > 0.0 {
                     if show_text {
                         draw_cluster_text(
                             frame,
-                            &abbr_large_numbers(buy_qty as f64),
+                            &abbr_large_numbers(buy_qty),
                             Point::new(area.bid_area_left, y),
                             text_size,
                             text_color,
@@ -1614,7 +1612,7 @@ fn draw_clusters(
                         );
                     }
 
-                    let bar_width = (buy_qty / max_cluster_qty) * right_area_width;
+                    let bar_width = (buy_qty / max_cluster_qty) as f32 * right_area_width;
                     if bar_width > 0.0 {
                         frame.fill_rectangle(
                             Point::new(area.bid_area_left, y - (cell_height / 2.0)),
@@ -1627,7 +1625,7 @@ fn draw_clusters(
                     if show_text {
                         draw_cluster_text(
                             frame,
-                            &abbr_large_numbers(sell_qty as f64),
+                            &abbr_large_numbers(sell_qty),
                             Point::new(area.ask_area_right, y),
                             text_size,
                             text_color,
@@ -1636,7 +1634,7 @@ fn draw_clusters(
                         );
                     }
 
-                    let bar_width = (sell_qty / max_cluster_qty) * left_area_width;
+                    let bar_width = (sell_qty / max_cluster_qty) as f32 * left_area_width;
                     if bar_width > 0.0 {
                         frame.fill_rectangle(
                             Point::new(area.ask_area_right, y - (cell_height / 2.0)),
@@ -1649,8 +1647,7 @@ fn draw_clusters(
                 if let Some((threshold, color_scale, ignore_zeros)) = imbalance
                     && area.imb_marker_width > 0.0
                 {
-                    let higher_price =
-                        Price::from_f32(price.to_f32() + step.to_f32_lossy()).round_to_step(step);
+                    let higher_price = price.add_steps(1, step);
 
                     let rect_width = ((area.imb_marker_width - 1.0) / 2.0).max(1.0);
 
@@ -1736,7 +1733,7 @@ fn draw_imbalance_markers(
     price_to_y: &impl Fn(Price) -> f32,
     footprint: &KlineTrades,
     price: Price,
-    sell_qty: f32,
+    sell_qty: f64,
     higher_price: Price,
     threshold: usize,
     color_scale: Option<usize>,
@@ -1752,7 +1749,7 @@ fn draw_imbalance_markers(
     }
 
     if let Some(group) = footprint.trades.get(&higher_price) {
-        let diagonal_buy_qty = group.buy_qty.to_f32_lossy();
+        let diagonal_buy_qty = group.buy_qty.to_f64();
 
         if ignore_zeros && diagonal_buy_qty <= 0.0 {
             return;
@@ -1760,17 +1757,17 @@ fn draw_imbalance_markers(
 
         let rect_height = cell_height / 2.0;
 
-        let alpha_from_ratio = |ratio: f32| -> f32 {
+        let alpha_from_ratio = |ratio: f64| -> f32 {
             if let Some(scale) = color_scale {
-                let divisor = (scale as f32 / 10.0) - 1.0;
-                (0.2 + 0.8 * ((ratio - 1.0) / divisor).min(1.0)).min(1.0)
+                let divisor = (scale as f64 / 10.0) - 1.0;
+                (0.2 + 0.8 * ((ratio - 1.0) / divisor).min(1.0)).min(1.0) as f32
             } else {
                 1.0
             }
         };
 
         if diagonal_buy_qty >= sell_qty {
-            let required_qty = sell_qty * (100 + threshold) as f32 / 100.0;
+            let required_qty = sell_qty * (100 + threshold) as f64 / 100.0;
             if diagonal_buy_qty > required_qty {
                 let ratio = diagonal_buy_qty / required_qty;
                 let alpha = alpha_from_ratio(ratio);
@@ -1783,7 +1780,7 @@ fn draw_imbalance_markers(
                 );
             }
         } else {
-            let required_qty = diagonal_buy_qty * (100 + threshold) as f32 / 100.0;
+            let required_qty = diagonal_buy_qty * (100 + threshold) as f64 / 100.0;
             if sell_qty > required_qty {
                 let ratio = sell_qty / required_qty;
                 let alpha = alpha_from_ratio(ratio);
@@ -1924,7 +1921,7 @@ fn draw_crosshair_tooltip(
     };
 
     if let Some(kline) = kline_opt {
-        let change_pct = ((kline.close - kline.open).to_f32() / kline.open.to_f32()) * 100.0;
+        let change_pct = ((kline.close - kline.open) / kline.open * 100.0) as f32;
         let change_color = if change_pct >= 0.0 {
             palette.success.base.color
         } else {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -725,7 +725,7 @@ impl KlineChart {
                     rounded_highest,
                     rounded_lowest,
                 )
-                .into(),
+                .to_f32_lossy(),
             PlotData::TickBased(tick_aggr) => {
                 let earliest = earliest as usize;
                 let latest = latest as usize;
@@ -738,7 +738,7 @@ impl KlineChart {
                         rounded_highest,
                         rounded_lowest,
                     )
-                    .into()
+                    .to_f32_lossy()
             }
         }
     }
@@ -1419,7 +1419,7 @@ fn effective_cluster_qty(
             .max()
             .unwrap_or_default(),
     };
-    let individual_max_f32 = f32::from(individual_max);
+    let individual_max_f32 = individual_max.to_f32_lossy();
 
     match scaling {
         ClusterScaling::VisibleRange => Qty::scale_or_one(visible_max as f64) as f32,
@@ -1470,8 +1470,8 @@ fn draw_clusters(
             let bar_alpha = if show_text { 0.25 } else { 1.0 };
 
             for (price, group) in &footprint.trades {
-                let buy_qty = f32::from(group.buy_qty);
-                let sell_qty = f32::from(group.sell_qty);
+                let buy_qty = group.buy_qty.to_f32_lossy();
+                let sell_qty = group.sell_qty.to_f32_lossy();
                 let y = price_to_y(*price);
 
                 match cluster_kind {
@@ -1504,7 +1504,7 @@ fn draw_clusters(
                         }
                     }
                     ClusterKind::DeltaProfile => {
-                        let delta = f32::from(group.delta_qty());
+                        let delta = group.delta_qty().to_f32_lossy();
                         if show_text {
                             draw_cluster_text(
                                 frame,
@@ -1597,8 +1597,8 @@ fn draw_clusters(
             let left_area_width = (area.ask_area_right - left_min_x).max(0.0);
 
             for (price, group) in &footprint.trades {
-                let buy_qty = f32::from(group.buy_qty);
-                let sell_qty = f32::from(group.sell_qty);
+                let buy_qty = group.buy_qty.to_f32_lossy();
+                let sell_qty = group.sell_qty.to_f32_lossy();
                 let y = price_to_y(*price);
 
                 if buy_qty > 0.0 && right_area_width > 0.0 {
@@ -1688,9 +1688,9 @@ fn draw_clusters(
     }
 
     if show_text {
-        let mut total_buy = Qty::zero();
-        let mut total_sell = Qty::zero();
-        let mut total_delta = Qty::zero();
+        let mut total_buy = Qty::ZERO;
+        let mut total_sell = Qty::ZERO;
+        let mut total_delta = Qty::ZERO;
 
         for group in footprint.trades.values() {
             total_buy += group.buy_qty;
@@ -1713,7 +1713,7 @@ fn draw_clusters(
             Alignment::Start,
         );
 
-        let delta_color = if total_delta >= Qty::zero() {
+        let delta_color = if total_delta >= Qty::ZERO {
             palette.success.base.color
         } else {
             palette.danger.base.color
@@ -1752,7 +1752,7 @@ fn draw_imbalance_markers(
     }
 
     if let Some(group) = footprint.trades.get(&higher_price) {
-        let diagonal_buy_qty = f32::from(group.buy_qty);
+        let diagonal_buy_qty = group.buy_qty.to_f32_lossy();
 
         if ignore_zeros && diagonal_buy_qty <= 0.0 {
             return;

--- a/src/chart/scale.rs
+++ b/src/chart/scale.rs
@@ -733,7 +733,7 @@ impl canvas::Program<Message> for AxisLabelsY<'_> {
                 };
 
                 let (price, color) = label.get_with_color(palette);
-                let price = price.to_f32();
+                let price = price.to_f32_lossy();
 
                 let price_label = LabelContent {
                     content: format!("{:.*}", self.decimals, price),

--- a/src/chart/scale/linear.rs
+++ b/src/chart/scale/linear.rs
@@ -46,7 +46,7 @@ pub fn generate_labels(
             content: if let Some(decimals) = decimals {
                 format!("{highest:.decimals$}")
             } else {
-                abbr_large_numbers(highest)
+                abbr_large_numbers(highest as f64)
             },
             background_color: None,
             text_color,
@@ -75,7 +75,7 @@ pub fn generate_labels(
             let content = if let Some(decimals) = decimals {
                 format!("{value:.decimals$}")
             } else {
-                abbr_large_numbers(value)
+                abbr_large_numbers(value as f64)
             };
 
             let label = LabelContent {

--- a/src/modal/audio.rs
+++ b/src/modal/audio.rs
@@ -271,9 +271,12 @@ impl AudioStream {
                             }
                             data::audio::Threshold::Qty(v) => {
                                 column = column.push(
-                                    row![text(format!("Any trade's size in buffer ≥ {}", v))]
-                                        .padding(8)
-                                        .spacing(4),
+                                    row![text(format!(
+                                        "Any trade's size in buffer ≥ {:.2}",
+                                        v.to_f64()
+                                    ))]
+                                    .padding(8)
+                                    .spacing(4),
                                 );
                             }
                         }

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -62,7 +62,7 @@ pub fn heatmap_cfg_view<'a>(
                     false,
                 )
             },
-            |value| format!(">${}", format_with_commas(*value)),
+            |value| format!(">${}", format_with_commas(*value as f64)),
             Some(500.0),
         )
     };
@@ -83,7 +83,7 @@ pub fn heatmap_cfg_view<'a>(
                     false,
                 )
             },
-            |value| format!(">${}", format_with_commas(*value)),
+            |value| format!(">${}", format_with_commas(*value as f64)),
             Some(5000.0),
         )
     };
@@ -304,7 +304,7 @@ pub fn heatmap_shader_cfg_view<'a>(
                     false,
                 )
             },
-            |value| format!(">${}", format_with_commas(*value)),
+            |value| format!(">${}", format_with_commas(*value as f64)),
             Some(500.0),
         )
     };
@@ -325,7 +325,7 @@ pub fn heatmap_shader_cfg_view<'a>(
                     false,
                 )
             },
-            |value| format!(">${}", format_with_commas(*value)),
+            |value| format!(">${}", format_with_commas(*value as f64)),
             Some(5000.0),
         )
     };
@@ -421,7 +421,7 @@ pub fn timesales_cfg_view<'a>(
                     false,
                 )
             },
-            |value| format!(">${}", format_with_commas(*value)),
+            |value| format!(">${}", format_with_commas(*value as f64)),
             Some(500.0),
         );
 

--- a/src/modal/pane/stream.rs
+++ b/src/modal/pane/stream.rs
@@ -6,7 +6,7 @@ use crate::{
 use data::chart::Basis;
 use exchange::{
     StreamPairKind, TickMultiplier, Timeframe,
-    adapter::{Exchange, allowed_multipliers_for_min_tick},
+    adapter::Exchange,
     unit::{MinTicksize, PriceStep},
 };
 use iced::{
@@ -550,17 +550,9 @@ impl Modifier {
                         || matches!(kind, ModifierKind::Footprint(_, _));
 
                     let allowed_tm = if allows_custom_tsizes {
-                        exchange::TickMultiplier::ALL.to_vec()
-                    } else if let Some(min_tick) = self.min_ticksize {
-                        let allow = allowed_multipliers_for_min_tick(min_tick);
-
-                        exchange::TickMultiplier::ALL
-                            .iter()
-                            .copied()
-                            .filter(|tm| allow.contains(&tm.0))
-                            .collect()
+                        TickMultiplier::ALL.to_vec()
                     } else {
-                        vec![]
+                        exchange.allowed_tick_multipliers(self.min_ticksize)
                     };
 
                     let tick_multiplier_grid = modifiers_grid(

--- a/src/screen/dashboard/panel/ladder.rs
+++ b/src/screen/dashboard/panel/ladder.rs
@@ -561,9 +561,9 @@ impl Ladder {
         trade_sell_color: iced::Color,
         cols: &ColumnRanges,
     ) {
-        let order_qty_f32 = f32::from(order_qty);
-        let trade_buy_qty_f32 = f32::from(trade_buy_qty);
-        let trade_sell_qty_f32 = f32::from(trade_sell_qty);
+        let order_qty_f32 = order_qty.to_f32_lossy();
+        let trade_buy_qty_f32 = trade_buy_qty.to_f32_lossy();
+        let trade_sell_qty_f32 = trade_sell_qty.to_f32_lossy();
 
         if is_bid {
             Self::fill_bar(
@@ -831,11 +831,11 @@ impl Ladder {
                 continue;
             }
 
-            maxima.vis_max_order_qty = maxima.vis_max_order_qty.max(f32::from(order_qty));
+            maxima.vis_max_order_qty = maxima.vis_max_order_qty.max(order_qty.to_f32_lossy());
             let (buy_t, sell_t) = self.trade_qty_at(price);
             maxima.vis_max_trade_qty = maxima
                 .vis_max_trade_qty
-                .max(f32::from(buy_t).max(f32::from(sell_t)));
+                .max(buy_t.to_f32_lossy().max(sell_t.to_f32_lossy()));
 
             let row = if is_bid {
                 DomRow::Bid {

--- a/src/screen/dashboard/panel/ladder.rs
+++ b/src/screen/dashboard/panel/ladder.rs
@@ -194,7 +194,7 @@ impl Ladder {
     }
 
     fn format_quantity(&self, qty: Qty) -> String {
-        data::util::abbr_large_numbers(qty.to_f32_lossy())
+        data::util::abbr_large_numbers(qty.to_f64())
     }
 }
 

--- a/src/screen/dashboard/panel/timeandsales.rs
+++ b/src/screen/dashboard/panel/timeandsales.rs
@@ -389,8 +389,8 @@ impl canvas::Program<Message> for TimeAndSales {
 
                             (
                                 buy_ratio,
-                                data::util::abbr_large_numbers(buy_val),
-                                data::util::abbr_large_numbers(sell_val),
+                                data::util::abbr_large_numbers(buy_val as f64),
+                                data::util::abbr_large_numbers(sell_val as f64),
                             )
                         }
                     };
@@ -542,7 +542,7 @@ impl canvas::Program<Message> for TimeAndSales {
                 frame.fill_text(trade_price);
 
                 let trade_qty = create_text(
-                    data::util::abbr_large_numbers(trade.qty.to_f32_lossy()),
+                    data::util::abbr_large_numbers(trade.qty.to_f64()),
                     Point {
                         x: row_width * 0.9,
                         y: y_position,

--- a/src/screen/dashboard/panel/timeandsales.rs
+++ b/src/screen/dashboard/panel/timeandsales.rs
@@ -127,7 +127,7 @@ impl TimeAndSales {
                     size_in_quote_ccy,
                 );
 
-                if trade_size_value >= size_filter {
+                if trade_size_value as f32 >= size_filter {
                     self.max_filtered_qty = self.max_filtered_qty.max(trade_display.qty);
                 }
 
@@ -225,7 +225,7 @@ impl TimeAndSales {
                         t.display.price,
                         size_in_quote_ccy,
                     );
-                    trade_size >= size_filter
+                    trade_size as f32 >= size_filter
                 })
                 .map(|e| e.display.qty)
                 .fold(Qty::ZERO, Qty::max);
@@ -456,7 +456,7 @@ impl canvas::Program<Message> for TimeAndSales {
                         t.display.price,
                         size_in_quote_ccy,
                     );
-                    trade_size >= self.config.trade_size_filter
+                    trade_size as f32 >= self.config.trade_size_filter
                 })
                 .rev()
                 .skip(start_index)

--- a/src/screen/dashboard/tickers_table.rs
+++ b/src/screen/dashboard/tickers_table.rs
@@ -1649,7 +1649,7 @@ fn fetch_ticker_stats_task(
             .filter_map(|(ticker, info)| {
                 (ticker.exchange.venue() == venue).then_some(())?;
                 let contract_size = info.as_ref()?.contract_size?;
-                Some((*ticker, contract_size.as_f32()))
+                Some((*ticker, contract_size))
             })
             .collect()
     });

--- a/src/widget/chart/heatmap/instance.rs
+++ b/src/widget/chart/heatmap/instance.rs
@@ -337,7 +337,7 @@ impl InstanceBuilder {
 
                 let trade_size =
                     market_type.qty_in_quote_value(trade.qty, trade.price, size_in_quote_ccy);
-                if trade_size <= trade_size_filter {
+                if trade_size as f32 <= trade_size_filter {
                     continue;
                 }
 

--- a/src/widget/chart/heatmap/scene/depth_grid.rs
+++ b/src/widget/chart/heatmap/scene/depth_grid.rs
@@ -201,7 +201,7 @@ impl GridRing {
                 }
                 if order_size_filter > 0.0 {
                     let order_size = market_type.qty_in_quote_value(q, *price, size_in_quote_ccy);
-                    if order_size <= order_size_filter {
+                    if order_size as f32 <= order_size_filter {
                         continue;
                     }
                 }
@@ -582,7 +582,7 @@ impl GridRing {
             if order_size_filter > 0.0 {
                 let order_size =
                     market_type.qty_in_quote_value(qty_sum, rounded_price, size_in_quote_ccy);
-                if order_size <= order_size_filter {
+                if order_size as f32 <= order_size_filter {
                     return;
                 }
             }

--- a/src/widget/chart/heatmap/scene/pipeline/circle.rs
+++ b/src/widget/chart/heatmap/scene/pipeline/circle.rs
@@ -41,8 +41,8 @@ impl CircleInstance {
 
         let y_world = w.y_center_for_price_texture_aligned(trade.price, base_price, step, y_anchor);
 
-        let q = trade.qty.max(qty::Qty::zero()).to_f32_lossy();
-        let t = (q / max_trade_qty.to_scale_or_one()).clamp(0.0, 1.0);
+        let q = trade.qty.max(qty::Qty::zero()).to_f64();
+        let t = (q / max_trade_qty.to_scale_or_one()).clamp(0.0, 1.0) as f32;
         let radius_px = if let Some(scale_pct) = trade_size_scale {
             let scale_factor = (scale_pct as f32 / 100.0).max(0.0);
             Self::R_MIN_PX + t * (Self::R_MAX_PX - Self::R_MIN_PX) * scale_factor

--- a/src/widget/chart/heatmap/scene/pipeline/circle.rs
+++ b/src/widget/chart/heatmap/scene/pipeline/circle.rs
@@ -41,7 +41,7 @@ impl CircleInstance {
 
         let y_world = w.y_center_for_price_texture_aligned(trade.price, base_price, step, y_anchor);
 
-        let q = trade.qty.max(qty::Qty::zero()).to_f64();
+        let q = trade.qty.max(qty::Qty::ZERO).to_f64();
         let t = (q / max_trade_qty.to_scale_or_one()).clamp(0.0, 1.0) as f32;
         let radius_px = if let Some(scale_pct) = trade_size_scale {
             let scale_factor = (scale_pct as f32 / 100.0).max(0.0);

--- a/src/widget/chart/heatmap/scene/pipeline/rectangle.rs
+++ b/src/widget/chart/heatmap/scene/pipeline/rectangle.rs
@@ -130,8 +130,8 @@ impl RectInstance {
         w: &ViewWindow,
     ) -> Self {
         let denom = max_qty.to_scale_or_one();
-        let raw_overlay_h =
-            ((diff_qty.to_f64() / denom) * w.volume_area_max_height as f64).min(total_h.max(0.0_f32) as f64) as f32;
+        let raw_overlay_h = ((diff_qty.to_f64() / denom) * w.volume_area_max_height as f64)
+            .min(total_h.max(0.0_f32) as f64) as f32;
         let (overlay_h, subpx_alpha) = Self::extent_and_subpx_alpha(raw_overlay_h, w.cam_scale);
         let overlay_h = overlay_h.min(total_h.max(0.0));
 

--- a/src/widget/chart/heatmap/scene/pipeline/rectangle.rs
+++ b/src/widget/chart/heatmap/scene/pipeline/rectangle.rs
@@ -56,7 +56,7 @@ impl RectInstance {
         w: &ViewWindow,
         palette: &HeatmapPalette,
     ) -> Self {
-        let t = (qty.to_f32_lossy() / max_qty.to_scale_or_one()).clamp(0.0, 1.0);
+        let t = (qty.to_f64() / max_qty.to_scale_or_one()).clamp(0.0, 1.0) as f32;
         let raw_w_world = t * w.depth_profile_max_width;
         let (w_world, subpx_alpha) = Self::extent_and_subpx_alpha(raw_w_world, w.cam_scale);
         let center_x = 0.5 * w_world;
@@ -99,7 +99,7 @@ impl RectInstance {
             (palette.secondary_rgb, true)
         };
 
-        let raw_total_h = (total_qty.to_f32_lossy() / denom) * w.volume_area_max_height;
+        let raw_total_h = ((total_qty.to_f64() / denom) * w.volume_area_max_height as f64) as f32;
         let (total_h, subpx_alpha) = Self::extent_and_subpx_alpha(raw_total_h, w.cam_scale);
         let total_center_y = w.volume_area_bottom_y - 0.5 * total_h;
 
@@ -131,7 +131,7 @@ impl RectInstance {
     ) -> Self {
         let denom = max_qty.to_scale_or_one();
         let raw_overlay_h =
-            ((diff_qty.to_f32_lossy() / denom) * w.volume_area_max_height).min(total_h.max(0.0));
+            ((diff_qty.to_f64() / denom) * w.volume_area_max_height as f64).min(total_h.max(0.0_f32) as f64) as f32;
         let (overlay_h, subpx_alpha) = Self::extent_and_subpx_alpha(raw_overlay_h, w.cam_scale);
         let overlay_h = overlay_h.min(total_h.max(0.0));
 

--- a/src/widget/chart/heatmap/ui/overlay.rs
+++ b/src/widget/chart/heatmap/ui/overlay.rs
@@ -225,7 +225,7 @@ impl<'a> canvas::Program<Message> for OverlayCanvas<'a> {
                     let x_pos = bounds.width - OVERLAY_LABEL_PAD_PX;
 
                     frame.fill_text(canvas::Text {
-                        content: abbr_large_numbers(qty.into()),
+                        content: abbr_large_numbers(f64::from(qty)),
                         position: Point::new(x_pos, strip_top_y),
                         size: iced::Pixels(OVERLAY_SCALE_LABEL_TEXT_SIZE),
                         color: palette.background.base.text.scale_alpha(0.85),
@@ -259,7 +259,7 @@ impl<'a> canvas::Program<Message> for OverlayCanvas<'a> {
                             let ty = OVERLAY_LABEL_PAD_PX;
 
                             frame.fill_text(canvas::Text {
-                                content: abbr_large_numbers(qty.into()),
+                                content: abbr_large_numbers(f64::from(qty)),
                                 position: Point::new(tx, ty),
                                 size: iced::Pixels(OVERLAY_SCALE_LABEL_TEXT_SIZE),
                                 color: palette.background.base.text.scale_alpha(0.85),
@@ -300,7 +300,7 @@ impl<'a> canvas::Program<Message> for OverlayCanvas<'a> {
                             let ty = OVERLAY_LABEL_PAD_PX;
 
                             frame.fill_text(canvas::Text {
-                                content: abbr_large_numbers(qty.into()),
+                                content: abbr_large_numbers(f64::from(qty)),
                                 position: Point::new(tx, ty),
                                 size: iced::Pixels(OVERLAY_SCALE_LABEL_TEXT_SIZE),
                                 color: palette.background.base.text.scale_alpha(0.85),
@@ -467,7 +467,7 @@ impl<'a> canvas::Program<Message> for OverlayCanvas<'a> {
                     };
 
                     frame.fill_text(canvas::Text {
-                        content: abbr_large_numbers(qty),
+                        content: abbr_large_numbers(qty as f64),
                         position: layout.cell_center(row_idx, col_idx),
                         size: iced::Pixels(crate::style::text_size::TINY),
                         color: color.scale_alpha(0.95),

--- a/src/widget/chart/heatmap/view.rs
+++ b/src/widget/chart/heatmap/view.rs
@@ -884,7 +884,7 @@ impl DepthNormCache {
             )
         };
 
-        let max_qty = max_qty.to_scale_or_one();
+        let max_qty = max_qty.to_scale_or_one() as f32;
 
         self.key = Some(key);
         self.value = max_qty;


### PR DESCRIPTION
Fixes a precision error with notional(USD) `Volume` and `Qty` values.

This was especially noticeable when values are accumulated across datapoints(CVD indicator) and the individual rounding errors compound and shown as small discrepancies on data labels.