### PR TITLE
Add shared footprint summary calculations

### DIFF
--- a/data/src/chart/kline.rs
+++ b/data/src/chart/kline.rs
@@ -261,6 +261,51 @@ impl KlineTrades {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FootprintSummary {
+    pub buy: Qty,
+    pub sell: Qty,
+    pub total: Qty,
+    pub delta: Qty,
+    pub delta_pct: f64,
+}
+
+impl FootprintSummary {
+    pub fn new(buy: Qty, sell: Qty) -> Self {
+        let total = buy + sell;
+        let delta = buy - sell;
+        let total_f = total.to_f64();
+        let delta_pct = if total_f > 0.0 {
+            (delta.to_f64() / total_f) * 100.0
+        } else {
+            0.0
+        };
+
+        Self {
+            buy,
+            sell,
+            total,
+            delta,
+            delta_pct,
+        }
+    }
+
+    pub fn from_trades(footprint: &KlineTrades) -> Option<Self> {
+        if footprint.trades.is_empty() {
+            return None;
+        }
+
+        let (buy, sell) = footprint
+            .trades
+            .values()
+            .fold((Qty::ZERO, Qty::ZERO), |(buy, sell), group| {
+                (buy + group.buy_qty, sell + group.sell_qty)
+            });
+
+        Some(Self::new(buy, sell))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
 pub enum KlineChartKind {
     #[default]

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -9,8 +9,8 @@ use data::aggr::ticks::TickAggr;
 use data::aggr::time::TimeSeries;
 use data::chart::indicator::{Indicator, KlineIndicator};
 use data::chart::kline::{
-    ClusterKind, ClusterScaling, Config, FootprintStudy, KlineDataPoint, KlineTrades, NPoc,
-    PointOfControl,
+    ClusterKind, ClusterScaling, Config, FootprintStudy, FootprintSummary, KlineDataPoint,
+    KlineTrades, NPoc, PointOfControl,
 };
 use data::chart::{Autoscale, KlineChartKind, ViewConfig};
 
@@ -1685,24 +1685,16 @@ fn draw_clusters(
     }
 
     if show_text {
-        let mut total_buy = Qty::ZERO;
-        let mut total_sell = Qty::ZERO;
-        let mut total_delta = Qty::ZERO;
-
-        for group in footprint.trades.values() {
-            total_buy += group.buy_qty;
-            total_sell += group.sell_qty;
-            total_delta += group.delta_qty();
-        }
+        let Some(summary) = FootprintSummary::from_trades(footprint) else {
+            return;
+        };
 
         let summary_y = price_to_y(kline.low) + cell_height * 1.5;
         let line_spacing = text_size * 1.2;
 
-        let total_vol = total_buy + total_sell;
-
         draw_cluster_text(
             frame,
-            &format!("V: {}", abbr_large_numbers(total_vol.to_f64())),
+            &format!("V: {}", abbr_large_numbers(summary.total.to_f64())),
             Point::new(x_position, summary_y),
             text_size * 0.9,
             palette.background.weakest.text,
@@ -1710,7 +1702,7 @@ fn draw_clusters(
             Alignment::Start,
         );
 
-        let delta_color = if total_delta >= Qty::ZERO {
+        let delta_color = if summary.delta >= Qty::ZERO {
             palette.success.base.color
         } else {
             palette.danger.base.color
@@ -1718,7 +1710,7 @@ fn draw_clusters(
 
         draw_cluster_text(
             frame,
-            &format!("Δ: {}", abbr_large_numbers(total_delta.to_f64())),
+            &format!("Δ: {}", abbr_large_numbers(summary.delta.to_f64())),
             Point::new(x_position, summary_y + line_spacing),
             text_size * 0.9,
             delta_color,


### PR DESCRIPTION
  ## Summary

  This PR adds shared footprint summary calculations that can be reused by future footprint features.

  ## Changes

  - Add shared footprint summary calculation logic.
  - Compute buy volume, sell volume, total volume, delta, and delta percentage.
  - Keep the change isolated from Table mode, Bar Analysis, and customization work.

  ## Motivation

  Both Table footprint view and Bar Analysis need the same per-bar footprint summary values.

  Extracting this logic first keeps the follow-up PRs smaller, avoids duplicated calculations, and makes the later feature PRs
  easier to review.

  ## Validation

  - cargo fmt
  - cargo check
  - cargo clippy --all-targets --all-features -- -D warnings