### PR TITLE
feat: add footprint table mode and bar analysis

### DIFF
--- a/data/src/chart/indicator.rs
+++ b/data/src/chart/indicator.rs
@@ -13,6 +13,7 @@ pub trait Indicator: PartialEq + Display + 'static {
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize, Eq, Enum)]
 pub enum KlineIndicator {
     Volume,
+    BarAnalysis,
     CumulativeDelta,
     OpenInterest,
 }
@@ -30,10 +31,15 @@ impl KlineIndicator {
     // Indicator togglers on UI menus depend on these arrays.
     // Every variant needs to be in either SPOT, PERPS or both.
     /// Indicators that can be used with spot market tickers
-    const FOR_SPOT: [KlineIndicator; 2] = [KlineIndicator::Volume, KlineIndicator::CumulativeDelta];
-    /// Indicators that can be used with perpetual swap market tickers
-    const FOR_PERPS: [KlineIndicator; 3] = [
+    const FOR_SPOT: [KlineIndicator; 3] = [
         KlineIndicator::Volume,
+        KlineIndicator::BarAnalysis,
+        KlineIndicator::CumulativeDelta,
+    ];
+    /// Indicators that can be used with perpetual swap market tickers
+    const FOR_PERPS: [KlineIndicator; 4] = [
+        KlineIndicator::Volume,
+        KlineIndicator::BarAnalysis,
         KlineIndicator::CumulativeDelta,
         KlineIndicator::OpenInterest,
     ];
@@ -43,6 +49,7 @@ impl Display for KlineIndicator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             KlineIndicator::Volume => write!(f, "Volume"),
+            KlineIndicator::BarAnalysis => write!(f, "Bar Analysis"),
             KlineIndicator::CumulativeDelta => write!(f, "CVD"),
             KlineIndicator::OpenInterest => write!(f, "Open Interest"),
         }

--- a/data/src/chart/kline.rs
+++ b/data/src/chart/kline.rs
@@ -415,7 +415,7 @@ impl Default for Config {
         Self {
             data_labels_always_visible: false,
             show_footprint_summary: true,
-            show_footprint_table_candle: false,
+            show_footprint_table_candle: true,
         }
     }
 }

--- a/data/src/chart/kline.rs
+++ b/data/src/chart/kline.rs
@@ -152,7 +152,7 @@ impl GroupedTrades {
 
     pub fn max_cluster_qty(&self, cluster_kind: ClusterKind) -> Qty {
         match cluster_kind {
-            ClusterKind::BidAsk => self.buy_qty.max(self.sell_qty),
+            ClusterKind::BidAsk | ClusterKind::Table => self.buy_qty.max(self.sell_qty),
             ClusterKind::DeltaProfile => self.buy_qty.abs_diff(self.sell_qty),
             ClusterKind::VolumeProfile => self.total_qty(),
         }
@@ -375,13 +375,15 @@ pub enum ClusterKind {
     BidAsk,
     VolumeProfile,
     DeltaProfile,
+    Table,
 }
 
 impl ClusterKind {
-    pub const ALL: [ClusterKind; 3] = [
+    pub const ALL: [ClusterKind; 4] = [
         ClusterKind::BidAsk,
         ClusterKind::VolumeProfile,
         ClusterKind::DeltaProfile,
+        ClusterKind::Table,
     ];
 }
 
@@ -391,16 +393,31 @@ impl std::fmt::Display for ClusterKind {
             ClusterKind::BidAsk => write!(f, "Bid/Ask"),
             ClusterKind::VolumeProfile => write!(f, "Volume Profile"),
             ClusterKind::DeltaProfile => write!(f, "Delta Profile"),
+            ClusterKind::Table => write!(f, "Table"),
         }
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     // Whether to show last value labels on top right/left when not hovering
     // e.g. OHLC/bar change values for the main chart, or last value of an indicator series
     pub data_labels_always_visible: bool,
+    // Whether to show the footprint per-bar summary below each candle.
+    pub show_footprint_summary: bool,
+    // Whether to show a small candle next to footprint table clusters.
+    pub show_footprint_table_candle: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            data_labels_always_visible: false,
+            show_footprint_summary: true,
+            show_footprint_table_candle: false,
+        }
+    }
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]

--- a/data/src/chart/kline.rs
+++ b/data/src/chart/kline.rs
@@ -1,4 +1,4 @@
-use crate::aggr::time::DataPoint;
+use crate::{aggr::time::DataPoint, chart::indicator::KlineIndicator};
 use exchange::{
     Kline, Trade, UnixMs,
     unit::price::{Price, PriceStep},
@@ -319,6 +319,13 @@ pub enum KlineChartKind {
 }
 
 impl KlineChartKind {
+    pub fn allows_indicator(&self, indicator: KlineIndicator) -> bool {
+        !matches!(
+            (self, indicator),
+            (KlineChartKind::Candles, KlineIndicator::BarAnalysis)
+        )
+    }
+
     pub fn min_scaling(&self) -> f32 {
         match self {
             KlineChartKind::Footprint { .. } => 0.4,
@@ -385,6 +392,13 @@ impl ClusterKind {
         ClusterKind::DeltaProfile,
         ClusterKind::Table,
     ];
+
+    pub fn allows_study(&self, study: &FootprintStudy) -> bool {
+        !matches!(
+            (self, study),
+            (ClusterKind::Table, FootprintStudy::NPoC { .. })
+        )
+    }
 }
 
 impl std::fmt::Display for ClusterKind {

--- a/data/src/config/theme.rs
+++ b/data/src/config/theme.rs
@@ -345,3 +345,58 @@ pub fn from_hsv_degrees(h_deg: f32, s: f32, v: f32) -> Color {
     let hue = RgbHue::from_degrees(h_deg);
     from_hsva(Hsva::new(hue, s, v, 1.0))
 }
+
+/// Alpha-composite a foreground color over a background.
+pub fn composite_color(foreground: Color, background: Color) -> Color {
+    let alpha = foreground.a.clamp(0.0, 1.0);
+    Color {
+        r: foreground.r.mul_add(alpha, background.r * (1.0 - alpha)),
+        g: foreground.g.mul_add(alpha, background.g * (1.0 - alpha)),
+        b: foreground.b.mul_add(alpha, background.b * (1.0 - alpha)),
+        a: 1.0,
+    }
+}
+
+/// Compute the WCAG contrast ratio between two colors.
+pub fn contrast_ratio(a: Color, b: Color) -> f32 {
+    let l1 = relative_luminance(a);
+    let l2 = relative_luminance(b);
+    let lighter = l1.max(l2);
+    let darker = l1.min(l2);
+
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+/// Compute the relative luminance of a color per the WCAG specification.
+pub fn relative_luminance(color: Color) -> f32 {
+    let channel = |value: f32| {
+        if value <= 0.03928 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    };
+
+    (0.2126 * channel(color.r)) + (0.7152 * channel(color.g)) + (0.0722 * channel(color.b))
+}
+
+/// Linearly interpolate (mix) two colors by a foreground-weight factor.
+pub fn mix_color(foreground: Color, background: Color, foreground_weight: f32) -> Color {
+    let foreground_weight = foreground_weight.clamp(0.0, 1.0);
+    let background_weight = 1.0 - foreground_weight;
+
+    Color {
+        r: foreground
+            .r
+            .mul_add(foreground_weight, background.r * background_weight),
+        g: foreground
+            .g
+            .mul_add(foreground_weight, background.g * background_weight),
+        b: foreground
+            .b
+            .mul_add(foreground_weight, background.b * background_weight),
+        a: foreground
+            .a
+            .mul_add(foreground_weight, background.a * background_weight),
+    }
+}

--- a/src/chart/indicator/kline.rs
+++ b/src/chart/indicator/kline.rs
@@ -9,6 +9,7 @@ use exchange::{Kline, Timeframe, Trade, UnixMs};
 
 use super::plot::AnySeries;
 
+pub mod bar_analysis;
 pub mod cumulative_delta;
 pub mod open_interest;
 pub mod volume;
@@ -134,6 +135,9 @@ pub struct FetchCtx<'a> {
 pub fn make_empty(which: KlineIndicator) -> Box<dyn KlineIndicatorImpl> {
     match which {
         KlineIndicator::Volume => Box::new(super::kline::volume::VolumeIndicator::new()),
+        KlineIndicator::BarAnalysis => {
+            Box::new(super::kline::bar_analysis::BarAnalysisIndicator::new())
+        }
         KlineIndicator::CumulativeDelta => {
             Box::new(super::kline::cumulative_delta::CumulativeDeltaIndicator::new())
         }

--- a/src/chart/indicator/kline/bar_analysis.rs
+++ b/src/chart/indicator/kline/bar_analysis.rs
@@ -1,0 +1,332 @@
+use crate::{
+    chart::{
+        Caches, Interaction, Message, TEXT_SIZE, ViewState,
+        indicator::{
+            kline::{BasisSeriesExt, KlineIndicatorImpl},
+            plot::{AnySeries, Series},
+        },
+    },
+    style,
+};
+
+use data::chart::{
+    BasisSeries, PlotData,
+    kline::{FootprintSummary, KlineDataPoint},
+};
+use data::util::abbr_large_numbers;
+use exchange::{Kline, Trade};
+use iced::{
+    Alignment, Color, Element, Event, Length, Point, Rectangle, Renderer, Size, Theme, Vector,
+    mouse,
+    widget::{
+        Canvas,
+        canvas::{self, Cache, Geometry},
+        container, row, rule, space,
+    },
+};
+use std::{collections::BTreeMap, ops::RangeInclusive};
+
+pub struct BarAnalysisIndicator {
+    cache: Caches,
+    data: BasisSeries<FootprintSummary>,
+    settings: BarAnalysisSettings,
+}
+
+impl BarAnalysisIndicator {
+    pub fn new() -> Self {
+        Self {
+            cache: Caches::default(),
+            data: BasisSeries::default(),
+            settings: BarAnalysisSettings::default(),
+        }
+    }
+
+    fn indicator_elem<'a>(
+        &'a self,
+        main_chart: &'a ViewState,
+        visible_range: RangeInclusive<u64>,
+    ) -> Element<'a, Message> {
+        let canvas = Canvas::new(BarAnalysisCanvas {
+            cache: &self.cache.main,
+            ctx: main_chart,
+            series: self.data.as_plot_series(),
+            settings: self.settings,
+            visible_range,
+        })
+        .height(Length::Fill)
+        .width(Length::Fill);
+
+        row![
+            canvas,
+            rule::vertical(1).style(style::split_ruler),
+            container(space::vertical()).width(main_chart.y_labels_width())
+        ]
+        .into()
+    }
+
+    fn rebuild(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.data = source.map_basis_series(
+            |timeseries| {
+                timeseries
+                    .datapoints
+                    .iter()
+                    .filter_map(|(timestamp, dp)| {
+                        FootprintSummary::from_trades(&dp.footprint).map(|row| (*timestamp, row))
+                    })
+                    .collect::<BTreeMap<_, _>>()
+            },
+            |tickseries| {
+                tickseries
+                    .datapoints
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, dp)| {
+                        FootprintSummary::from_trades(&dp.footprint).map(|row| (idx as u64, row))
+                    })
+                    .collect::<BTreeMap<_, _>>()
+            },
+        );
+        self.clear_all_caches();
+    }
+}
+
+impl KlineIndicatorImpl for BarAnalysisIndicator {
+    fn clear_all_caches(&mut self) {
+        self.cache.clear_all();
+    }
+
+    fn clear_crosshair_caches(&mut self) {
+        self.cache.clear_crosshair();
+    }
+
+    fn element<'a>(
+        &'a self,
+        chart: &'a ViewState,
+        _data_labels_always_visible: bool,
+        visible_range: RangeInclusive<u64>,
+    ) -> Element<'a, Message> {
+        self.indicator_elem(chart, visible_range)
+    }
+
+    fn rebuild_from_source(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.rebuild(source);
+    }
+
+    fn on_insert_klines(&mut self, _klines: &[Kline], source: &PlotData<KlineDataPoint>) {
+        self.rebuild(source);
+    }
+
+    fn on_insert_trades(
+        &mut self,
+        _trades: &[Trade],
+        _old_dp_len: usize,
+        source: &PlotData<KlineDataPoint>,
+    ) {
+        self.rebuild(source);
+    }
+
+    fn on_ticksize_change(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.rebuild(source);
+    }
+
+    fn on_basis_change(&mut self, source: &PlotData<KlineDataPoint>) {
+        self.rebuild(source);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BarAnalysisSettings {
+    show_buy_sell: bool,
+    show_volume: bool,
+    show_delta: bool,
+    show_delta_pct: bool,
+}
+
+impl Default for BarAnalysisSettings {
+    fn default() -> Self {
+        Self {
+            show_buy_sell: true,
+            show_volume: true,
+            show_delta: true,
+            show_delta_pct: true,
+        }
+    }
+}
+
+struct BarAnalysisCanvas<'a> {
+    cache: &'a Cache,
+    ctx: &'a ViewState,
+    series: AnySeries<'a, FootprintSummary>,
+    settings: BarAnalysisSettings,
+    visible_range: RangeInclusive<u64>,
+}
+
+impl canvas::Program<Message> for BarAnalysisCanvas<'_> {
+    type State = Interaction;
+
+    fn update(
+        &self,
+        _state: &mut Self::State,
+        _event: &Event,
+        _bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Option<canvas::Action<Message>> {
+        None
+    }
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let ctx = self.ctx;
+        let palette = theme.extended_palette();
+
+        let geometry = self.cache.draw(renderer, bounds.size(), |frame| {
+            if ctx.bounds.width == 0.0 || ctx.scaling <= f32::EPSILON {
+                return;
+            }
+
+            let center = Vector::new(bounds.width / 2.0, bounds.height / 2.0);
+            frame.translate(center);
+            frame.scale(ctx.scaling);
+            frame.translate(Vector::new(
+                ctx.translation.x,
+                (-bounds.height / ctx.scaling) / 2.0,
+            ));
+
+            let pane_height = frame.height() / ctx.scaling;
+            let table_top = 3.0;
+            let table_height = (pane_height - 6.0).max(24.0);
+            let rows_count = {
+                let mut count: f32 = 0.0;
+                if self.settings.show_buy_sell {
+                    count += 2.0;
+                }
+                if self.settings.show_volume {
+                    count += 1.0;
+                }
+                if self.settings.show_delta {
+                    count += 1.0;
+                }
+                if self.settings.show_delta_pct {
+                    count += 1.0;
+                }
+                count.max(1.0)
+            };
+            let row_height = table_height / rows_count;
+            let column_width = ctx.cell_width;
+            let text_size = (row_height * 0.42).clamp(5.0, TEXT_SIZE * 0.75);
+            let border_color = palette.background.weakest.text.scale_alpha(0.25);
+            let view_left = -ctx.translation.x - bounds.width / ctx.scaling;
+            let view_right = -ctx.translation.x + bounds.width / ctx.scaling;
+
+            self.series
+                .for_each_in(self.visible_range.clone(), |x, row| {
+                    let column_left = ctx.interval_to_x(x) - column_width / 2.0;
+
+                    if column_left > view_right || column_left + column_width < view_left {
+                        return;
+                    }
+
+                    frame.fill_rectangle(
+                        Point::new(column_left, table_top),
+                        Size::new(column_width, table_height),
+                        palette.background.weakest.color.scale_alpha(0.22),
+                    );
+
+                    let delta_color = if row.delta.to_f64() >= 0.0 {
+                        palette.success.base.color
+                    } else {
+                        palette.danger.base.color
+                    };
+
+                    let mut rows = Vec::with_capacity(5);
+                    if self.settings.show_buy_sell {
+                        rows.push((
+                            format!("Ask {}", abbr_large_numbers(row.sell.to_f64())),
+                            palette.danger.base.color,
+                        ));
+                        rows.push((
+                            format!("Bid {}", abbr_large_numbers(row.buy.to_f64())),
+                            palette.success.base.color,
+                        ));
+                    }
+                    if self.settings.show_volume {
+                        rows.push((
+                            format!("Vol {}", abbr_large_numbers(row.total.to_f64())),
+                            palette.background.weakest.text,
+                        ));
+                    }
+                    if self.settings.show_delta {
+                        rows.push((
+                            format!("Δ {}", abbr_large_numbers(row.delta.to_f64())),
+                            delta_color,
+                        ));
+                    }
+                    if self.settings.show_delta_pct {
+                        rows.push((format!("Δ% {:+.1}%", row.delta_pct), delta_color));
+                    }
+
+                    for (idx, (label, color)) in rows.iter().enumerate() {
+                        let row_y = table_top + row_height * idx as f32;
+                        frame.fill_rectangle(
+                            Point::new(column_left, row_y),
+                            Size::new(column_width, 1.0),
+                            border_color,
+                        );
+                        draw_text(
+                            frame,
+                            label,
+                            Point::new(column_left + column_width / 2.0, row_y + row_height / 2.0),
+                            text_size,
+                            *color,
+                        );
+                    }
+
+                    frame.fill_rectangle(
+                        Point::new(column_left, table_top + table_height - 1.0),
+                        Size::new(column_width, 1.0),
+                        border_color,
+                    );
+                    frame.fill_rectangle(
+                        Point::new(column_left, table_top),
+                        Size::new(1.0, table_height),
+                        border_color,
+                    );
+                    frame.fill_rectangle(
+                        Point::new(column_left + column_width - 1.0, table_top),
+                        Size::new(1.0, table_height),
+                        border_color,
+                    );
+                });
+        });
+
+        vec![geometry]
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &Interaction,
+        _bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        mouse::Interaction::default()
+    }
+}
+
+fn draw_text(frame: &mut canvas::Frame, text: &str, position: Point, size: f32, color: Color) {
+    frame.fill_text(canvas::Text {
+        content: text.to_string(),
+        position,
+        size: iced::Pixels(size),
+        color,
+        align_x: Alignment::Center.into(),
+        align_y: Alignment::Center.into(),
+        font: style::AZERET_MONO,
+        ..canvas::Text::default()
+    });
+}

--- a/src/chart/indicator/kline/bar_analysis.rs
+++ b/src/chart/indicator/kline/bar_analysis.rs
@@ -190,17 +190,9 @@ impl canvas::Program<Message> for BarAnalysisCanvas<'_> {
                 return;
             }
 
-            let center = Vector::new(bounds.width / 2.0, bounds.height / 2.0);
-            frame.translate(center);
-            frame.scale(ctx.scaling);
-            frame.translate(Vector::new(
-                ctx.translation.x,
-                (-bounds.height / ctx.scaling) / 2.0,
-            ));
-
-            let pane_height = frame.height() / ctx.scaling;
-            let table_top = 3.0;
-            let table_height = (pane_height - 6.0).max(24.0);
+            let pane_height = bounds.height / ctx.scaling;
+            let table_top = 0.0;
+            let table_height = pane_height.max(24.0);
             let rows_count = {
                 let mut count: f32 = 0.0;
                 if self.settings.show_buy_sell {
@@ -219,90 +211,159 @@ impl canvas::Program<Message> for BarAnalysisCanvas<'_> {
             };
             let row_height = table_height / rows_count;
             let column_width = ctx.cell_width;
-            let text_size = (row_height * 0.42).clamp(5.0, TEXT_SIZE * 0.75);
-            let border_color = palette.background.weakest.text.scale_alpha(0.25);
+            let text_size = (row_height * 0.5).clamp(5.0, TEXT_SIZE);
+            let border_color = palette.background.strong.color;
+
+            let mut header_labels: Vec<&str> = Vec::with_capacity(5);
+            if self.settings.show_buy_sell {
+                header_labels.push("Buy");
+                header_labels.push("Sell");
+            }
+            if self.settings.show_volume {
+                header_labels.push("Total");
+            }
+            if self.settings.show_delta {
+                header_labels.push("Δ");
+            }
+            if self.settings.show_delta_pct {
+                header_labels.push("Δ%");
+            }
+
+            let max_label_chars = header_labels
+                .iter()
+                .map(|s| s.chars().count())
+                .max()
+                .unwrap_or(3);
+            let header_width = text_size * max_label_chars as f32 * 0.72 + 12.0;
+            let screen_text_size = text_size * ctx.scaling;
+            let screen_row_height = row_height * ctx.scaling;
+            let screen_table_top = table_top * ctx.scaling;
+            let screen_header_width = header_width * ctx.scaling;
+            let header_x = bounds.width - screen_header_width;
+
+            // Header row labels and separators
+            for (idx, label) in header_labels.iter().enumerate() {
+                let row_y = screen_table_top + screen_row_height * idx as f32;
+                if idx > 0 {
+                    frame.fill_rectangle(
+                        Point::new(header_x, row_y),
+                        Size::new(screen_header_width, 1.0),
+                        border_color,
+                    );
+                }
+                draw_text(
+                    frame,
+                    label,
+                    Point::new(
+                        header_x + screen_header_width / 2.0,
+                        row_y + screen_row_height / 2.0,
+                    ),
+                    screen_text_size,
+                    palette.background.weakest.text,
+                );
+            }
+
+            // Header vertical border
+            frame.fill_rectangle(
+                Point::new(header_x, screen_table_top),
+                Size::new(1.0, screen_row_height * rows_count),
+                border_color,
+            );
+
+            let header_left_chart =
+                (header_x - bounds.width / 2.0) / ctx.scaling - ctx.translation.x;
             let view_left = -ctx.translation.x - bounds.width / ctx.scaling;
-            let view_right = -ctx.translation.x + bounds.width / ctx.scaling;
+            let view_right =
+                (-ctx.translation.x + bounds.width / ctx.scaling).min(header_left_chart);
 
-            self.series
-                .for_each_in(self.visible_range.clone(), |x, row| {
-                    let column_left = ctx.interval_to_x(x) - column_width / 2.0;
+            let clip_region = Rectangle::new(
+                Point::new(0.0, screen_table_top),
+                Size::new(
+                    bounds.width - screen_header_width,
+                    screen_row_height * rows_count,
+                ),
+            );
+            frame.with_clip(clip_region, |frame| {
+                let center = Vector::new(bounds.width / 2.0, bounds.height / 2.0);
+                frame.translate(center);
+                frame.scale(ctx.scaling);
+                frame.translate(Vector::new(
+                    ctx.translation.x,
+                    (-bounds.height / ctx.scaling) / 2.0,
+                ));
 
-                    if column_left > view_right || column_left + column_width < view_left {
-                        return;
-                    }
+                self.series
+                    .for_each_in(self.visible_range.clone(), |x, row| {
+                        let column_left = ctx.interval_to_x(x) - column_width / 2.0;
 
-                    frame.fill_rectangle(
-                        Point::new(column_left, table_top),
-                        Size::new(column_width, table_height),
-                        palette.background.weakest.color.scale_alpha(0.22),
-                    );
+                        if column_left > view_right || column_left + column_width < view_left {
+                            return;
+                        }
 
-                    let delta_color = if row.delta.to_f64() >= 0.0 {
-                        palette.success.base.color
-                    } else {
-                        palette.danger.base.color
-                    };
-
-                    let mut rows = Vec::with_capacity(5);
-                    if self.settings.show_buy_sell {
-                        rows.push((
-                            format!("Ask {}", abbr_large_numbers(row.sell.to_f64())),
-                            palette.danger.base.color,
-                        ));
-                        rows.push((
-                            format!("Bid {}", abbr_large_numbers(row.buy.to_f64())),
-                            palette.success.base.color,
-                        ));
-                    }
-                    if self.settings.show_volume {
-                        rows.push((
-                            format!("Vol {}", abbr_large_numbers(row.total.to_f64())),
-                            palette.background.weakest.text,
-                        ));
-                    }
-                    if self.settings.show_delta {
-                        rows.push((
-                            format!("Δ {}", abbr_large_numbers(row.delta.to_f64())),
-                            delta_color,
-                        ));
-                    }
-                    if self.settings.show_delta_pct {
-                        rows.push((format!("Δ% {:+.1}%", row.delta_pct), delta_color));
-                    }
-
-                    for (idx, (label, color)) in rows.iter().enumerate() {
-                        let row_y = table_top + row_height * idx as f32;
                         frame.fill_rectangle(
-                            Point::new(column_left, row_y),
-                            Size::new(column_width, 1.0),
-                            border_color,
+                            Point::new(column_left, table_top),
+                            Size::new(column_width, table_height),
+                            palette.background.weakest.color.scale_alpha(0.22),
                         );
-                        draw_text(
-                            frame,
-                            label,
-                            Point::new(column_left + column_width / 2.0, row_y + row_height / 2.0),
-                            text_size,
-                            *color,
-                        );
-                    }
 
-                    frame.fill_rectangle(
-                        Point::new(column_left, table_top + table_height - 1.0),
-                        Size::new(column_width, 1.0),
-                        border_color,
-                    );
-                    frame.fill_rectangle(
-                        Point::new(column_left, table_top),
-                        Size::new(1.0, table_height),
-                        border_color,
-                    );
-                    frame.fill_rectangle(
-                        Point::new(column_left + column_width - 1.0, table_top),
-                        Size::new(1.0, table_height),
-                        border_color,
-                    );
-                });
+                        let delta_color = if row.delta.to_f64() >= 0.0 {
+                            palette.success.base.color
+                        } else {
+                            palette.danger.base.color
+                        };
+
+                        let mut rows: Vec<(String, Color)> = Vec::with_capacity(5);
+                        if self.settings.show_buy_sell {
+                            rows.push((
+                                abbr_large_numbers(row.buy.to_f64()),
+                                palette.success.base.color,
+                            ));
+                            rows.push((
+                                abbr_large_numbers(row.sell.to_f64()),
+                                palette.danger.base.color,
+                            ));
+                        }
+                        if self.settings.show_volume {
+                            rows.push((
+                                abbr_large_numbers(row.total.to_f64()),
+                                palette.background.weakest.text,
+                            ));
+                        }
+                        if self.settings.show_delta {
+                            rows.push((abbr_large_numbers(row.delta.to_f64()), delta_color));
+                        }
+                        if self.settings.show_delta_pct {
+                            rows.push((format!("{:+.1}%", row.delta_pct), delta_color));
+                        }
+
+                        for (idx, (label, color)) in rows.iter().enumerate() {
+                            let row_y = table_top + row_height * idx as f32;
+                            if idx > 0 {
+                                frame.fill_rectangle(
+                                    Point::new(column_left, row_y),
+                                    Size::new(column_width, 1.0),
+                                    border_color,
+                                );
+                            }
+                            draw_text(
+                                frame,
+                                label,
+                                Point::new(
+                                    column_left + column_width / 2.0,
+                                    row_y + row_height / 2.0,
+                                ),
+                                text_size,
+                                *color,
+                            );
+                        }
+
+                        frame.fill_rectangle(
+                            Point::new(column_left, table_top),
+                            Size::new(1.0, table_height),
+                            border_color.scale_alpha(0.4),
+                        );
+                    });
+            });
         });
 
         vec![geometry]

--- a/src/chart/indicator/kline/bar_analysis.rs
+++ b/src/chart/indicator/kline/bar_analysis.rs
@@ -112,17 +112,89 @@ impl KlineIndicatorImpl for BarAnalysisIndicator {
         self.rebuild(source);
     }
 
-    fn on_insert_klines(&mut self, _klines: &[Kline], source: &PlotData<KlineDataPoint>) {
-        self.rebuild(source);
+    fn on_insert_klines(&mut self, klines: &[Kline], source: &PlotData<KlineDataPoint>) {
+        match source {
+            PlotData::TimeBased(timeseries) => {
+                if let Some(data) = self.data.time_mut() {
+                    for kline in klines {
+                        match timeseries.datapoints.get(&kline.time) {
+                            Some(dp) => match FootprintSummary::from_trades(&dp.footprint) {
+                                Some(summary) => {
+                                    data.insert(kline.time, summary);
+                                }
+                                None => {
+                                    data.remove(&kline.time);
+                                }
+                            },
+                            None => {
+                                data.remove(&kline.time);
+                            }
+                        }
+                    }
+                }
+            }
+            PlotData::TickBased(_) => {}
+        }
+        self.clear_all_caches();
     }
 
     fn on_insert_trades(
         &mut self,
-        _trades: &[Trade],
-        _old_dp_len: usize,
+        trades: &[Trade],
+        old_dp_len: usize,
         source: &PlotData<KlineDataPoint>,
     ) {
-        self.rebuild(source);
+        match source {
+            PlotData::TimeBased(timeseries) => {
+                let mut affected = Vec::new();
+                for trade in trades {
+                    let rounded = trade.time.floor_to(timeseries.interval);
+                    if !affected.contains(&rounded) {
+                        affected.push(rounded);
+                    }
+                }
+                if let Some(data) = self.data.time_mut() {
+                    for ts in affected {
+                        match timeseries.datapoints.get(&ts) {
+                            Some(dp) => match FootprintSummary::from_trades(&dp.footprint) {
+                                Some(summary) => {
+                                    data.insert(ts, summary);
+                                }
+                                None => {
+                                    data.remove(&ts);
+                                }
+                            },
+                            None => {
+                                data.remove(&ts);
+                            }
+                        }
+                    }
+                }
+            }
+            PlotData::TickBased(tick_aggr) => {
+                let new_len = tick_aggr.datapoints.len();
+                let start = old_dp_len.saturating_sub(1);
+                if let Some(data) = self.data.tick_mut() {
+                    // Remove entries for any indices that no longer exist
+                    // (safety measure - bars are only appended, never removed)
+                    data.retain(|&idx, _| idx < new_len as u64);
+                    // Recompute the last old bar (may have been modified) and any new bars
+                    for idx in start..new_len {
+                        if let Some(dp) = tick_aggr.datapoints.get(idx) {
+                            match FootprintSummary::from_trades(&dp.footprint) {
+                                Some(summary) => {
+                                    data.insert(idx as u64, summary);
+                                }
+                                None => {
+                                    data.remove(&(idx as u64));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.clear_all_caches();
     }
 
     fn on_ticksize_change(&mut self, source: &PlotData<KlineDataPoint>) {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -21,7 +21,7 @@ use exchange::{Kline, OpenInterest as OIData, TickerInfo, Trade, UnixMs};
 use iced::task::Handle;
 use iced::theme::palette::Extended;
 use iced::widget::canvas::{self, Event, Geometry, Path, Stroke};
-use iced::{Alignment, Element, Point, Rectangle, Renderer, Size, Theme, Vector, mouse};
+use iced::{Alignment, Color, Element, Point, Rectangle, Renderer, Size, Theme, Vector, mouse};
 
 use enum_map::EnumMap;
 use std::time::Instant;
@@ -1048,7 +1048,6 @@ impl canvas::Program<Message> for KlineChart {
                         step: self.tick_size(),
                         show_text,
                         show_summary: self.visual_config.show_footprint_summary,
-                        show_table_candle: self.visual_config.show_footprint_table_candle,
                         imbalance,
                         cluster_kind: *clusters,
                         spacing: content_spacing,
@@ -1505,7 +1504,6 @@ where
     step: PriceStep,
     show_text: bool,
     show_summary: bool,
-    show_table_candle: bool,
     imbalance: Option<(usize, Option<usize>, bool)>,
     cluster_kind: ClusterKind,
     spacing: ContentGaps,
@@ -1663,7 +1661,6 @@ fn draw_clusters<F>(
                 kline,
                 palette,
                 spacing,
-                ctx.show_table_candle,
             );
             let table_width = area.width();
             let half_width = table_width / 2.0;
@@ -1703,9 +1700,9 @@ fn draw_clusters<F>(
                         frame.fill_rectangle(
                             Point::new(area.table_left, row_top),
                             Size::new(half_width, cell_height),
-                            palette.danger.weak.color.scale_alpha(alpha.max(0.65)),
+                            imbalance_background(palette, ImbalanceSide::Sell, alpha),
                         );
-                        sell_text_color = palette.danger.base.color;
+                        sell_text_color = imbalance_text_color(palette);
                     }
 
                     if let Some(alpha) = buy_imbalance_alpha(
@@ -1720,9 +1717,9 @@ fn draw_clusters<F>(
                         frame.fill_rectangle(
                             Point::new(area.table_left + half_width, row_top),
                             Size::new(half_width, cell_height),
-                            palette.success.weak.color.scale_alpha(alpha.max(0.65)),
+                            imbalance_background(palette, ImbalanceSide::Buy, alpha),
                         );
-                        buy_text_color = palette.success.base.color;
+                        buy_text_color = imbalance_text_color(palette);
                     }
                 }
 
@@ -1973,7 +1970,7 @@ fn draw_imbalance_markers(
                 frame.fill_rectangle(
                     Point::new(buyside_x, y - (rect_height / 2.0)),
                     Size::new(rect_width, rect_height),
-                    palette.success.weak.color.scale_alpha(alpha),
+                    imbalance_background(palette, ImbalanceSide::Buy, alpha),
                 );
             }
         } else {
@@ -1986,10 +1983,56 @@ fn draw_imbalance_markers(
                 frame.fill_rectangle(
                     Point::new(sellside_x, y - (rect_height / 2.0)),
                     Size::new(rect_width, rect_height),
-                    palette.danger.weak.color.scale_alpha(alpha),
+                    imbalance_background(palette, ImbalanceSide::Sell, alpha),
                 );
             }
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ImbalanceSide {
+    Buy,
+    Sell,
+}
+
+fn imbalance_background(palette: &Extended, side: ImbalanceSide, alpha: f32) -> Color {
+    let accent = match side {
+        ImbalanceSide::Buy => palette.success.strong.color,
+        ImbalanceSide::Sell => palette.danger.strong.color,
+    };
+    let alpha = alpha.clamp(0.0, 1.0);
+
+    if palette.is_dark {
+        let tint = 0.28 + (alpha * 0.32);
+        mix_color(accent, palette.background.strongest.color, tint)
+    } else {
+        let tint = 0.18 + (alpha * 0.24);
+        mix_color(accent, palette.background.weak.color, tint)
+    }
+}
+
+fn imbalance_text_color(palette: &Extended) -> Color {
+    palette.background.base.text
+}
+
+fn mix_color(foreground: Color, background: Color, foreground_weight: f32) -> Color {
+    let foreground_weight = foreground_weight.clamp(0.0, 1.0);
+    let background_weight = 1.0 - foreground_weight;
+
+    Color {
+        r: foreground
+            .r
+            .mul_add(foreground_weight, background.r * background_weight),
+        g: foreground
+            .g
+            .mul_add(foreground_weight, background.g * background_weight),
+        b: foreground
+            .b
+            .mul_add(foreground_weight, background.b * background_weight),
+        a: foreground
+            .a
+            .mul_add(foreground_weight, background.a * background_weight),
     }
 }
 
@@ -2336,15 +2379,7 @@ impl TableArea {
         kline: &Kline,
         palette: &Extended,
         spacing: ContentGaps,
-        show_candle: bool,
     ) -> Self {
-        if !show_candle {
-            return Self {
-                table_left: content_left,
-                table_right: content_right,
-            };
-        }
-
         let candle_center_x = content_left + candle_width / 2.0;
         draw_footprint_kline(
             frame,

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1652,6 +1652,11 @@ fn draw_clusters<F>(
             let half_width = table_width / 2.0;
             let cell_border = 1.0;
             let grid_color = palette.background.weakest.text.scale_alpha(0.32);
+            let max_table_qty = footprint.trades.values().fold(0.0_f64, |max_qty, group| {
+                max_qty
+                    .max(group.buy_qty.to_f64())
+                    .max(group.sell_qty.to_f64())
+            });
 
             for (price, group) in &footprint.trades {
                 let buy_qty = group.buy_qty.to_f64();
@@ -1662,16 +1667,27 @@ fn draw_clusters<F>(
                 frame.fill_rectangle(
                     Point::new(area.table_left, row_top),
                     Size::new(half_width, cell_height),
-                    palette.danger.base.color.scale_alpha(0.14),
+                    volume_cell_background(palette, ImbalanceSide::Sell, sell_qty, max_table_qty),
                 );
                 frame.fill_rectangle(
                     Point::new(area.table_left + half_width, row_top),
                     Size::new(half_width, cell_height),
-                    palette.success.base.color.scale_alpha(0.14),
+                    volume_cell_background(palette, ImbalanceSide::Buy, buy_qty, max_table_qty),
                 );
-
-                let mut sell_text_color = text_color;
-                let mut buy_text_color = text_color;
+                let sell_text_color = volume_cell_text_color(
+                    palette,
+                    ImbalanceSide::Sell,
+                    sell_qty,
+                    max_table_qty,
+                    text_color,
+                );
+                let buy_text_color = volume_cell_text_color(
+                    palette,
+                    ImbalanceSide::Buy,
+                    buy_qty,
+                    max_table_qty,
+                    text_color,
+                );
 
                 if let Some((threshold, color_scale, ignore_zeros)) = imbalance {
                     if let Some(alpha) = sell_imbalance_alpha(
@@ -1683,12 +1699,18 @@ fn draw_clusters<F>(
                         color_scale,
                         ignore_zeros,
                     ) {
-                        frame.fill_rectangle(
-                            Point::new(area.table_left, row_top),
-                            Size::new(half_width, cell_height),
-                            imbalance_background(palette, ImbalanceSide::Sell, alpha),
+                        draw_table_imbalance_marker(
+                            frame,
+                            palette,
+                            ImbalanceSide::Sell,
+                            alpha,
+                            sell_qty,
+                            max_table_qty,
+                            Rectangle::new(
+                                Point::new(area.table_left, row_top),
+                                Size::new(half_width, cell_height),
+                            ),
                         );
-                        sell_text_color = imbalance_text_color(palette);
                     }
 
                     if let Some(alpha) = buy_imbalance_alpha(
@@ -1700,12 +1722,18 @@ fn draw_clusters<F>(
                         color_scale,
                         ignore_zeros,
                     ) {
-                        frame.fill_rectangle(
-                            Point::new(area.table_left + half_width, row_top),
-                            Size::new(half_width, cell_height),
-                            imbalance_background(palette, ImbalanceSide::Buy, alpha),
+                        draw_table_imbalance_marker(
+                            frame,
+                            palette,
+                            ImbalanceSide::Buy,
+                            alpha,
+                            buy_qty,
+                            max_table_qty,
+                            Rectangle::new(
+                                Point::new(area.table_left + half_width, row_top),
+                                Size::new(half_width, cell_height),
+                            ),
                         );
-                        buy_text_color = imbalance_text_color(palette);
                     }
                 }
 
@@ -1982,6 +2010,135 @@ enum ImbalanceSide {
     Sell,
 }
 
+fn volume_cell_background(
+    palette: &Extended,
+    side: ImbalanceSide,
+    qty: f64,
+    max_qty: f64,
+) -> Color {
+    const MIN_ALPHA: f32 = 0.10;
+    const MAX_ALPHA: f32 = 0.64;
+
+    let intensity = if max_qty > 0.0 {
+        (qty / max_qty).clamp(0.0, 1.0) as f32
+    } else {
+        0.0
+    };
+    let alpha = MIN_ALPHA + intensity * (MAX_ALPHA - MIN_ALPHA);
+
+    match side {
+        ImbalanceSide::Buy => palette.success.base.color.scale_alpha(alpha),
+        ImbalanceSide::Sell => palette.danger.base.color.scale_alpha(alpha),
+    }
+}
+
+fn volume_cell_text_color(
+    palette: &Extended,
+    side: ImbalanceSide,
+    qty: f64,
+    max_qty: f64,
+    default_color: Color,
+) -> Color {
+    let cell_color = volume_cell_background(palette, side, qty, max_qty);
+    let cell_background = composite_color(cell_color, palette.background.base.color);
+    let inverted_color = palette.background.base.color;
+
+    if contrast_ratio(cell_background, inverted_color)
+        > contrast_ratio(cell_background, default_color)
+    {
+        inverted_color
+    } else {
+        default_color
+    }
+}
+
+fn draw_table_imbalance_marker(
+    frame: &mut canvas::Frame,
+    palette: &Extended,
+    side: ImbalanceSide,
+    alpha: f32,
+    qty: f64,
+    max_qty: f64,
+    cell: Rectangle,
+) {
+    let marker_width = (cell.width * 0.24).clamp(5.0, 11.0).min(cell.width * 0.42);
+    let marker_height = (cell.height * 0.72)
+        .clamp(6.0, 13.0)
+        .min(cell.height.max(0.0));
+    if marker_width <= 0.0 || marker_height <= 0.0 {
+        return;
+    }
+
+    let inset = (cell.width * 0.04).clamp(1.0, 3.0);
+    let center_y = cell.y + (cell.height / 2.0);
+    let top = center_y - (marker_height / 2.0);
+    let bottom = center_y + (marker_height / 2.0);
+    let volume_intensity = if max_qty > 0.0 {
+        (qty / max_qty).clamp(0.0, 1.0) as f32
+    } else {
+        0.0
+    };
+    let imbalance_strength = alpha.clamp(0.0, 1.0);
+    let marker_alpha = 0.58 + (volume_intensity * 0.34) + (imbalance_strength * 0.08);
+    let marker_alpha = marker_alpha.clamp(0.58, 1.0);
+    let color = match side {
+        ImbalanceSide::Buy => palette.success.strong.color.scale_alpha(marker_alpha),
+        ImbalanceSide::Sell => palette.danger.strong.color.scale_alpha(marker_alpha),
+    };
+
+    let mut builder = canvas::path::Builder::new();
+    match side {
+        ImbalanceSide::Buy => {
+            let right = cell.x + cell.width - inset;
+            let left = right - marker_width;
+            builder.move_to(Point::new(right, top));
+            builder.line_to(Point::new(left, center_y));
+            builder.line_to(Point::new(right, bottom));
+        }
+        ImbalanceSide::Sell => {
+            let left = cell.x + inset;
+            let right = left + marker_width;
+            builder.move_to(Point::new(left, top));
+            builder.line_to(Point::new(right, center_y));
+            builder.line_to(Point::new(left, bottom));
+        }
+    }
+    builder.close();
+
+    frame.fill(&builder.build(), color);
+}
+
+fn composite_color(foreground: Color, background: Color) -> Color {
+    let alpha = foreground.a.clamp(0.0, 1.0);
+    Color {
+        r: foreground.r.mul_add(alpha, background.r * (1.0 - alpha)),
+        g: foreground.g.mul_add(alpha, background.g * (1.0 - alpha)),
+        b: foreground.b.mul_add(alpha, background.b * (1.0 - alpha)),
+        a: 1.0,
+    }
+}
+
+fn contrast_ratio(a: Color, b: Color) -> f32 {
+    let l1 = relative_luminance(a);
+    let l2 = relative_luminance(b);
+    let lighter = l1.max(l2);
+    let darker = l1.min(l2);
+
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+fn relative_luminance(color: Color) -> f32 {
+    let channel = |value: f32| {
+        if value <= 0.03928 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    };
+
+    (0.2126 * channel(color.r)) + (0.7152 * channel(color.g)) + (0.0722 * channel(color.b))
+}
+
 fn imbalance_background(palette: &Extended, side: ImbalanceSide, alpha: f32) -> Color {
     let accent = match side {
         ImbalanceSide::Buy => palette.success.strong.color,
@@ -1996,10 +2153,6 @@ fn imbalance_background(palette: &Extended, side: ImbalanceSide, alpha: f32) -> 
         let tint = 0.18 + (alpha * 0.24);
         mix_color(accent, palette.background.weak.color, tint)
     }
-}
-
-fn imbalance_text_color(palette: &Extended) -> Color {
-    palette.background.base.text
 }
 
 fn mix_color(foreground: Color, background: Color, foreground_weight: f32) -> Color {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -63,7 +63,9 @@ impl Chart for KlineChart {
         let mut elements = vec![];
 
         for selected_indicator in enabled {
-            if !KlineIndicator::for_market(market).contains(selected_indicator) {
+            if !Self::allows_indicator_for_kind(&self.kind, *selected_indicator)
+                || !KlineIndicator::for_market(market).contains(selected_indicator)
+            {
                 continue;
             }
             if let Some(indi) = self.indicators[*selected_indicator].as_ref() {
@@ -183,6 +185,7 @@ impl KlineChart {
         visual_config: Option<Config>,
     ) -> Self {
         let visual_config = visual_config.unwrap_or_default();
+        let kind = Self::sanitized_kind(kind.clone());
 
         match basis {
             Basis::Time(interval) => {
@@ -194,7 +197,7 @@ impl KlineChart {
                     .latest_timestamp()
                     .map_or(0, |timestamp| timestamp.as_u64());
                 let (scale_high, scale_low) = timeseries.price_scale({
-                    match kind {
+                    match &kind {
                         KlineChartKind::Footprint { .. } => 12,
                         KlineChartKind::Candles => 60,
                     }
@@ -208,11 +211,11 @@ impl KlineChart {
                     .unwrap_or(1)
                     .max(1) as f32;
 
-                let cell_width = match kind {
+                let cell_width = match &kind {
                     KlineChartKind::Footprint { .. } => 80.0,
                     KlineChartKind::Candles => 4.0,
                 };
-                let cell_height = match kind {
+                let cell_height = match &kind {
                     KlineChartKind::Footprint { .. } => 800.0 / y_ticks,
                     KlineChartKind::Candles => 200.0 / y_ticks,
                 };
@@ -248,6 +251,9 @@ impl KlineChart {
 
                 let mut indicators = EnumMap::default();
                 for &i in enabled_indicators {
+                    if !Self::allows_indicator_for_kind(&kind, i) {
+                        continue;
+                    }
                     let mut indi = indicator::kline::make_empty(i);
                     indi.rebuild_from_source(&data_source);
                     indicators[i] = Some(indi);
@@ -267,11 +273,11 @@ impl KlineChart {
                 }
             }
             Basis::Tick(interval) => {
-                let cell_width = match kind {
+                let cell_width = match &kind {
                     KlineChartKind::Footprint { .. } => 80.0,
                     KlineChartKind::Candles => 4.0,
                 };
-                let cell_height = match kind {
+                let cell_height = match &kind {
                     KlineChartKind::Footprint { .. } => 90.0,
                     KlineChartKind::Candles => 8.0,
                 };
@@ -305,6 +311,9 @@ impl KlineChart {
 
                 let mut indicators = EnumMap::default();
                 for &i in enabled_indicators {
+                    if !Self::allows_indicator_for_kind(&kind, i) {
+                        continue;
+                    }
                     let mut indi = indicator::kline::make_empty(i);
                     indi.rebuild_from_source(&data_source);
                     indicators[i] = Some(indi);
@@ -516,10 +525,15 @@ impl KlineChart {
 
     pub fn set_cluster_kind(&mut self, new_kind: ClusterKind) {
         if let KlineChartKind::Footprint {
-            ref mut clusters, ..
+            ref mut clusters,
+            ref mut studies,
+            ..
         } = self.kind
         {
             *clusters = new_kind;
+            if new_kind == ClusterKind::Table {
+                studies.retain(|study| !matches!(study, FootprintStudy::NPoC { .. }));
+            }
         }
 
         self.invalidate(None);
@@ -598,10 +612,19 @@ impl KlineChart {
 
     pub fn set_studies(&mut self, new_studies: Vec<FootprintStudy>) {
         if let KlineChartKind::Footprint {
-            ref mut studies, ..
+            clusters,
+            ref mut studies,
+            ..
         } = self.kind
         {
-            *studies = new_studies;
+            *studies = if clusters == ClusterKind::Table {
+                new_studies
+                    .into_iter()
+                    .filter(|study| !matches!(study, FootprintStudy::NPoC { .. }))
+                    .collect()
+            } else {
+                new_studies
+            };
         }
 
         self.invalidate(None);
@@ -843,13 +866,16 @@ impl KlineChart {
                                     top_padding += outer_padding;
                                     bottom_padding += outer_padding;
 
-                                    bottom_padding = bottom_padding.max(footprint_summary_padding(
-                                        provisional_cell_height,
-                                        chart.scaling,
-                                        chart.cell_width,
-                                        tick_size,
-                                        clusters,
-                                    ));
+                                    if self.visual_config.show_footprint_summary {
+                                        bottom_padding =
+                                            bottom_padding.max(footprint_summary_padding(
+                                                provisional_cell_height,
+                                                chart.scaling,
+                                                chart.cell_width,
+                                                tick_size,
+                                                clusters,
+                                            ));
+                                    }
                                 }
                             }
 
@@ -879,6 +905,10 @@ impl KlineChart {
     }
 
     pub fn toggle_indicator(&mut self, indicator: KlineIndicator) {
+        if !Self::allows_indicator_for_kind(&self.kind, indicator) {
+            return;
+        }
+
         let prev_indi_count = self.indicators.values().filter(|v| v.is_some()).count();
 
         if self.indicators[indicator].is_some() {
@@ -897,6 +927,27 @@ impl KlineChart {
                 Some(prev_indi_count),
             );
         }
+    }
+}
+
+impl KlineChart {
+    fn sanitized_kind(mut kind: KlineChartKind) -> KlineChartKind {
+        if let KlineChartKind::Footprint {
+            clusters, studies, ..
+        } = &mut kind
+            && *clusters == ClusterKind::Table
+        {
+            studies.retain(|study| !matches!(study, FootprintStudy::NPoC { .. }));
+        }
+
+        kind
+    }
+
+    fn allows_indicator_for_kind(kind: &KlineChartKind, indicator: KlineIndicator) -> bool {
+        !matches!(
+            (kind, indicator),
+            (KlineChartKind::Candles, KlineIndicator::BarAnalysis)
+        )
     }
 }
 
@@ -988,22 +1039,24 @@ impl canvas::Program<Message> for KlineChart {
                         footprint_cluster_min_width(*clusters),
                     );
 
-                    draw_all_npocs(
-                        &self.data_source,
-                        frame,
-                        price_to_y,
-                        interval_to_x,
-                        candle_width,
-                        chart.cell_width,
-                        chart.cell_height,
-                        palette,
-                        studies,
-                        earliest,
-                        latest,
-                        *clusters,
-                        content_spacing,
-                        imbalance.is_some(),
-                    );
+                    if *clusters != ClusterKind::Table {
+                        draw_all_npocs(
+                            &self.data_source,
+                            frame,
+                            price_to_y,
+                            interval_to_x,
+                            candle_width,
+                            chart.cell_width,
+                            chart.cell_height,
+                            palette,
+                            studies,
+                            earliest,
+                            latest,
+                            *clusters,
+                            content_spacing,
+                            imbalance.is_some(),
+                        );
+                    }
 
                     render_data_source(
                         &self.data_source,
@@ -1027,6 +1080,8 @@ impl canvas::Program<Message> for KlineChart {
                                 text_size,
                                 self.tick_size(),
                                 show_text,
+                                self.visual_config.show_footprint_summary,
+                                self.visual_config.show_footprint_table_candle,
                                 imbalance,
                                 kline,
                                 trades,
@@ -1282,12 +1337,14 @@ fn draw_all_npocs(
 
     let candle_lane_factor: f32 = match cluster_kind {
         ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => 0.25,
-        ClusterKind::BidAsk => 1.0,
+        ClusterKind::BidAsk | ClusterKind::Table => 1.0,
     };
 
     let start_x_for = |cell_center_x: f32| -> f32 {
         match cluster_kind {
-            ClusterKind::BidAsk => cell_center_x + (candle_width / 2.0) + spacing.candle_to_cluster,
+            ClusterKind::BidAsk | ClusterKind::Table => {
+                cell_center_x + (candle_width / 2.0) + spacing.candle_to_cluster
+            }
             ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => {
                 let content_left = (cell_center_x - (cell_width / 2.0)) + inset;
                 let candle_lane_left = content_left
@@ -1303,7 +1360,7 @@ fn draw_all_npocs(
 
     let wick_x_for = |cell_center_x: f32| -> f32 {
         match cluster_kind {
-            ClusterKind::BidAsk => cell_center_x, // not used for BidAsk clustering
+            ClusterKind::BidAsk | ClusterKind::Table => cell_center_x,
             ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => {
                 let content_left = (cell_center_x - (cell_width / 2.0)) + inset;
                 let candle_lane_left = content_left
@@ -1320,7 +1377,9 @@ fn draw_all_npocs(
 
     let end_x_for = |cell_center_x: f32| -> f32 {
         match cluster_kind {
-            ClusterKind::BidAsk => cell_center_x - (candle_width / 2.0) - spacing.candle_to_cluster,
+            ClusterKind::BidAsk | ClusterKind::Table => {
+                cell_center_x - (candle_width / 2.0) - spacing.candle_to_cluster
+            }
             ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => wick_x_for(cell_center_x),
         }
     };
@@ -1400,7 +1459,7 @@ fn effective_cluster_qty(
     cluster_kind: ClusterKind,
 ) -> f64 {
     let individual_max = match cluster_kind {
-        ClusterKind::BidAsk => footprint
+        ClusterKind::BidAsk | ClusterKind::Table => footprint
             .trades
             .values()
             .map(|group| group.buy_qty.max(group.sell_qty))
@@ -1442,6 +1501,8 @@ fn draw_clusters(
     text_size: f32,
     step: PriceStep,
     show_text: bool,
+    show_summary: bool,
+    show_table_candle: bool,
     imbalance: Option<(usize, Option<usize>, bool)>,
     kline: &Kline,
     footprint: &KlineTrades,
@@ -1569,6 +1630,127 @@ fn draw_clusters(
                 palette,
             );
         }
+        ClusterKind::Table => {
+            let area = TableArea::new(
+                frame,
+                &price_to_y,
+                content_left,
+                content_right,
+                candle_width,
+                kline,
+                palette,
+                spacing,
+                show_table_candle,
+            );
+            let table_width = area.width();
+            let half_width = table_width / 2.0;
+            let cell_border = 1.0;
+            let grid_color = palette.background.weakest.text.scale_alpha(0.32);
+
+            for (price, group) in &footprint.trades {
+                let buy_qty = group.buy_qty.to_f64();
+                let sell_qty = group.sell_qty.to_f64();
+                let y = price_to_y(*price);
+                let row_top = y - (cell_height / 2.0);
+
+                frame.fill_rectangle(
+                    Point::new(area.table_left, row_top),
+                    Size::new(half_width, cell_height),
+                    palette.danger.base.color.scale_alpha(0.14),
+                );
+                frame.fill_rectangle(
+                    Point::new(area.table_left + half_width, row_top),
+                    Size::new(half_width, cell_height),
+                    palette.success.base.color.scale_alpha(0.14),
+                );
+
+                let mut sell_text_color = text_color;
+                let mut buy_text_color = text_color;
+
+                if let Some((threshold, color_scale, ignore_zeros)) = imbalance {
+                    if let Some(alpha) = sell_imbalance_alpha(
+                        footprint,
+                        *price,
+                        sell_qty,
+                        step,
+                        threshold,
+                        color_scale,
+                        ignore_zeros,
+                    ) {
+                        frame.fill_rectangle(
+                            Point::new(area.table_left, row_top),
+                            Size::new(half_width, cell_height),
+                            palette.danger.weak.color.scale_alpha(alpha.max(0.65)),
+                        );
+                        sell_text_color = palette.danger.base.color;
+                    }
+
+                    if let Some(alpha) = buy_imbalance_alpha(
+                        footprint,
+                        *price,
+                        buy_qty,
+                        step,
+                        threshold,
+                        color_scale,
+                        ignore_zeros,
+                    ) {
+                        frame.fill_rectangle(
+                            Point::new(area.table_left + half_width, row_top),
+                            Size::new(half_width, cell_height),
+                            palette.success.weak.color.scale_alpha(alpha.max(0.65)),
+                        );
+                        buy_text_color = palette.success.base.color;
+                    }
+                }
+
+                frame.fill_rectangle(
+                    Point::new(area.table_left, row_top),
+                    Size::new(table_width, cell_border),
+                    grid_color,
+                );
+                frame.fill_rectangle(
+                    Point::new(area.table_left, row_top + cell_height - cell_border),
+                    Size::new(table_width, cell_border),
+                    grid_color,
+                );
+                frame.fill_rectangle(
+                    Point::new(area.table_left, row_top),
+                    Size::new(cell_border, cell_height),
+                    grid_color,
+                );
+                frame.fill_rectangle(
+                    Point::new(area.table_left + half_width, row_top),
+                    Size::new(cell_border, cell_height),
+                    grid_color,
+                );
+                frame.fill_rectangle(
+                    Point::new(area.table_right - cell_border, row_top),
+                    Size::new(cell_border, cell_height),
+                    grid_color,
+                );
+
+                if show_text {
+                    draw_cluster_text(
+                        frame,
+                        &abbr_large_numbers(sell_qty),
+                        Point::new(area.table_left + half_width - 3.0, y),
+                        text_size,
+                        sell_text_color,
+                        Alignment::End,
+                        Alignment::Center,
+                    );
+                    draw_cluster_text(
+                        frame,
+                        &abbr_large_numbers(buy_qty),
+                        Point::new(area.table_left + half_width + 3.0, y),
+                        text_size,
+                        buy_text_color,
+                        Alignment::Start,
+                        Alignment::Center,
+                    );
+                }
+            }
+        }
         ClusterKind::BidAsk => {
             let area = BidAskArea::new(
                 x_position,
@@ -1684,7 +1866,7 @@ fn draw_clusters(
         }
     }
 
-    if show_text {
+    if show_text && show_summary {
         let Some(summary) = FootprintSummary::from_trades(footprint) else {
             return;
         };
@@ -1786,6 +1968,77 @@ fn draw_imbalance_markers(
             }
         }
     }
+}
+
+fn buy_imbalance_alpha(
+    footprint: &KlineTrades,
+    price: Price,
+    buy_qty: f64,
+    step: PriceStep,
+    threshold: usize,
+    color_scale: Option<usize>,
+    ignore_zeros: bool,
+) -> Option<f32> {
+    let lower_price = price.add_steps(-1, step);
+    let diagonal_sell_qty = footprint
+        .trades
+        .get(&lower_price)
+        .map(|group| group.sell_qty.to_f64())
+        .unwrap_or_default();
+
+    if ignore_zeros && (buy_qty <= 0.0 || diagonal_sell_qty <= 0.0) {
+        return None;
+    }
+
+    imbalance_alpha(buy_qty, diagonal_sell_qty, threshold, color_scale)
+}
+
+fn sell_imbalance_alpha(
+    footprint: &KlineTrades,
+    price: Price,
+    sell_qty: f64,
+    step: PriceStep,
+    threshold: usize,
+    color_scale: Option<usize>,
+    ignore_zeros: bool,
+) -> Option<f32> {
+    let higher_price = price.add_steps(1, step);
+    let diagonal_buy_qty = footprint
+        .trades
+        .get(&higher_price)
+        .map(|group| group.buy_qty.to_f64())
+        .unwrap_or_default();
+
+    if ignore_zeros && (sell_qty <= 0.0 || diagonal_buy_qty <= 0.0) {
+        return None;
+    }
+
+    imbalance_alpha(sell_qty, diagonal_buy_qty, threshold, color_scale)
+}
+
+fn imbalance_alpha(
+    dominant_qty: f64,
+    opposite_qty: f64,
+    threshold: usize,
+    color_scale: Option<usize>,
+) -> Option<f32> {
+    let required_qty = opposite_qty * (100 + threshold) as f64 / 100.0;
+
+    if required_qty <= 0.0 {
+        return (dominant_qty > 0.0).then_some(1.0);
+    }
+
+    if dominant_qty <= required_qty {
+        return None;
+    }
+
+    let ratio = dominant_qty / required_qty;
+    Some(if let Some(scale) = color_scale {
+        let divisor = (scale as f64 / 10.0) - 1.0;
+        (0.2 + 0.8 * ((ratio - 1.0) / divisor).min(1.0)).min(1.0) as f32
+    } else {
+        1.0
+    })
 }
 
 impl ContentGaps {
@@ -2045,11 +2298,58 @@ impl BidAskArea {
     }
 }
 
+struct TableArea {
+    table_left: f32,
+    table_right: f32,
+}
+
+impl TableArea {
+    fn new(
+        frame: &mut canvas::Frame,
+        price_to_y: &impl Fn(Price) -> f32,
+        content_left: f32,
+        content_right: f32,
+        candle_width: f32,
+        kline: &Kline,
+        palette: &Extended,
+        spacing: ContentGaps,
+        show_candle: bool,
+    ) -> Self {
+        if !show_candle {
+            return Self {
+                table_left: content_left,
+                table_right: content_right,
+            };
+        }
+
+        let candle_center_x = content_left + candle_width / 2.0;
+        draw_footprint_kline(
+            frame,
+            price_to_y,
+            candle_center_x,
+            candle_width,
+            kline,
+            palette,
+        );
+
+        Self {
+            table_left: (content_left + candle_width + spacing.candle_to_cluster)
+                .min(content_right),
+            table_right: content_right,
+        }
+    }
+
+    fn width(&self) -> f32 {
+        (self.table_right - self.table_left).max(0.0)
+    }
+}
+
 #[inline]
 fn footprint_cluster_min_width(cluster_kind: ClusterKind) -> f32 {
     match cluster_kind {
         ClusterKind::VolumeProfile | ClusterKind::DeltaProfile => 80.0,
         ClusterKind::BidAsk => 120.0,
+        ClusterKind::Table => 100.0,
     }
 }
 

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1640,12 +1640,6 @@ fn draw_clusters(
             let half_width = table_width / 2.0;
             let cell_border = 1.0;
             let grid_color = layout.pal.background.weakest.text.scale_alpha(0.32);
-            let max_table_qty = footprint.trades.values().fold(0.0_f64, |max_qty, group| {
-                max_qty
-                    .max(group.buy_qty.to_f64())
-                    .max(group.sell_qty.to_f64())
-            });
-
             for (price, group) in &footprint.trades {
                 let buy_qty = group.buy_qty.to_f64();
                 let sell_qty = group.sell_qty.to_f64();
@@ -1659,26 +1653,31 @@ fn draw_clusters(
                         layout.pal,
                         ImbalanceSide::Sell,
                         sell_qty,
-                        max_table_qty,
+                        max_cluster_qty,
                     ),
                 );
                 frame.fill_rectangle(
                     Point::new(area.table_left + half_width, row_top),
                     Size::new(half_width, layout.cell_h),
-                    volume_cell_background(layout.pal, ImbalanceSide::Buy, buy_qty, max_table_qty),
+                    volume_cell_background(
+                        layout.pal,
+                        ImbalanceSide::Buy,
+                        buy_qty,
+                        max_cluster_qty,
+                    ),
                 );
                 let sell_text_color = volume_cell_text_color(
                     layout.pal,
                     ImbalanceSide::Sell,
                     sell_qty,
-                    max_table_qty,
+                    max_cluster_qty,
                     text_color,
                 );
                 let buy_text_color = volume_cell_text_color(
                     layout.pal,
                     ImbalanceSide::Buy,
                     buy_qty,
-                    max_table_qty,
+                    max_cluster_qty,
                     text_color,
                 );
 
@@ -1698,7 +1697,7 @@ fn draw_clusters(
                             ImbalanceSide::Sell,
                             alpha,
                             sell_qty,
-                            max_table_qty,
+                            max_cluster_qty,
                             Rectangle::new(
                                 Point::new(area.table_left, row_top),
                                 Size::new(half_width, layout.cell_h),
@@ -1721,7 +1720,7 @@ fn draw_clusters(
                             ImbalanceSide::Buy,
                             alpha,
                             buy_qty,
-                            max_table_qty,
+                            max_cluster_qty,
                             Rectangle::new(
                                 Point::new(area.table_left + half_width, row_top),
                                 Size::new(half_width, layout.cell_h),

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -63,7 +63,7 @@ impl Chart for KlineChart {
         let mut elements = vec![];
 
         for selected_indicator in enabled {
-            if !Self::allows_indicator_for_kind(&self.kind, *selected_indicator)
+            if !self.kind.allows_indicator(*selected_indicator)
                 || !KlineIndicator::for_market(market).contains(selected_indicator)
             {
                 continue;
@@ -251,7 +251,7 @@ impl KlineChart {
 
                 let mut indicators = EnumMap::default();
                 for &i in enabled_indicators {
-                    if !Self::allows_indicator_for_kind(&kind, i) {
+                    if !kind.allows_indicator(i) {
                         continue;
                     }
                     let mut indi = indicator::kline::make_empty(i);
@@ -311,7 +311,7 @@ impl KlineChart {
 
                 let mut indicators = EnumMap::default();
                 for &i in enabled_indicators {
-                    if !Self::allows_indicator_for_kind(&kind, i) {
+                    if !kind.allows_indicator(i) {
                         continue;
                     }
                     let mut indi = indicator::kline::make_empty(i);
@@ -531,9 +531,7 @@ impl KlineChart {
         } = self.kind
         {
             *clusters = new_kind;
-            if new_kind == ClusterKind::Table {
-                studies.retain(|study| !matches!(study, FootprintStudy::NPoC { .. }));
-            }
+            studies.retain(|study| new_kind.allows_study(study));
         }
 
         self.invalidate(None);
@@ -617,14 +615,10 @@ impl KlineChart {
             ..
         } = self.kind
         {
-            *studies = if clusters == ClusterKind::Table {
-                new_studies
-                    .into_iter()
-                    .filter(|study| !matches!(study, FootprintStudy::NPoC { .. }))
-                    .collect()
-            } else {
-                new_studies
-            };
+            *studies = new_studies
+                .into_iter()
+                .filter(|study| clusters.allows_study(study))
+                .collect();
         }
 
         self.invalidate(None);
@@ -905,7 +899,7 @@ impl KlineChart {
     }
 
     pub fn toggle_indicator(&mut self, indicator: KlineIndicator) {
-        if !Self::allows_indicator_for_kind(&self.kind, indicator) {
+        if !self.kind.allows_indicator(indicator) {
             return;
         }
 
@@ -935,19 +929,11 @@ impl KlineChart {
         if let KlineChartKind::Footprint {
             clusters, studies, ..
         } = &mut kind
-            && *clusters == ClusterKind::Table
         {
-            studies.retain(|study| !matches!(study, FootprintStudy::NPoC { .. }));
+            studies.retain(|study| clusters.allows_study(study));
         }
 
         kind
-    }
-
-    fn allows_indicator_for_kind(kind: &KlineChartKind, indicator: KlineIndicator) -> bool {
-        !matches!(
-            (kind, indicator),
-            (KlineChartKind::Candles, KlineIndicator::BarAnalysis)
-        )
     }
 }
 

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -14,6 +14,7 @@ use data::chart::kline::{
 };
 use data::chart::{Autoscale, KlineChartKind, ViewConfig};
 
+use data::config::theme::{composite_color, contrast_ratio, mix_color};
 use data::util::abbr_large_numbers;
 use exchange::unit::{Price, PriceStep, Qty};
 use exchange::{Kline, OpenInterest as OIData, TickerInfo, Trade, UnixMs};
@@ -2087,37 +2088,6 @@ fn draw_table_imbalance_marker(
     frame.fill_rectangle(Point::new(x, cell.y), Size::new(bar_w, cell.height), color);
 }
 
-fn composite_color(foreground: Color, background: Color) -> Color {
-    let alpha = foreground.a.clamp(0.0, 1.0);
-    Color {
-        r: foreground.r.mul_add(alpha, background.r * (1.0 - alpha)),
-        g: foreground.g.mul_add(alpha, background.g * (1.0 - alpha)),
-        b: foreground.b.mul_add(alpha, background.b * (1.0 - alpha)),
-        a: 1.0,
-    }
-}
-
-fn contrast_ratio(a: Color, b: Color) -> f32 {
-    let l1 = relative_luminance(a);
-    let l2 = relative_luminance(b);
-    let lighter = l1.max(l2);
-    let darker = l1.min(l2);
-
-    (lighter + 0.05) / (darker + 0.05)
-}
-
-fn relative_luminance(color: Color) -> f32 {
-    let channel = |value: f32| {
-        if value <= 0.03928 {
-            value / 12.92
-        } else {
-            ((value + 0.055) / 1.055).powf(2.4)
-        }
-    };
-
-    (0.2126 * channel(color.r)) + (0.7152 * channel(color.g)) + (0.0722 * channel(color.b))
-}
-
 fn imbalance_background(palette: &Extended, side: ImbalanceSide, alpha: f32) -> Color {
     let accent = match side {
         ImbalanceSide::Buy => palette.success.strong.color,
@@ -2131,26 +2101,6 @@ fn imbalance_background(palette: &Extended, side: ImbalanceSide, alpha: f32) -> 
     } else {
         let tint = 0.18 + (alpha * 0.24);
         mix_color(accent, palette.background.weak.color, tint)
-    }
-}
-
-fn mix_color(foreground: Color, background: Color, foreground_weight: f32) -> Color {
-    let foreground_weight = foreground_weight.clamp(0.0, 1.0);
-    let background_weight = 1.0 - foreground_weight;
-
-    Color {
-        r: foreground
-            .r
-            .mul_add(foreground_weight, background.r * background_weight),
-        g: foreground
-            .g
-            .mul_add(foreground_weight, background.g * background_weight),
-        b: foreground
-            .b
-            .mul_add(foreground_weight, background.b * background_weight),
-        a: foreground
-            .a
-            .mul_add(foreground_weight, background.a * background_weight),
     }
 }
 

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -2018,15 +2018,14 @@ fn volume_cell_background(
     qty: f64,
     max_qty: f64,
 ) -> Color {
-    const MIN_ALPHA: f32 = 0.10;
-    const MAX_ALPHA: f32 = 0.64;
+    const MIN_ALPHA: f32 = 0.04;
 
     let intensity = if max_qty > 0.0 {
         (qty / max_qty).clamp(0.0, 1.0) as f32
     } else {
         0.0
     };
-    let alpha = MIN_ALPHA + intensity * (MAX_ALPHA - MIN_ALPHA);
+    let alpha = MIN_ALPHA + intensity * (1.0 - MIN_ALPHA);
 
     match side {
         ImbalanceSide::Buy => palette.success.base.color.scale_alpha(alpha),
@@ -2063,51 +2062,30 @@ fn draw_table_imbalance_marker(
     max_qty: f64,
     cell: Rectangle,
 ) {
-    let marker_width = (cell.width * 0.24).clamp(5.0, 11.0).min(cell.width * 0.42);
-    let marker_height = (cell.height * 0.72)
-        .clamp(6.0, 13.0)
-        .min(cell.height.max(0.0));
-    if marker_width <= 0.0 || marker_height <= 0.0 {
+    if cell.height <= 0.0 {
         return;
     }
 
-    let inset = (cell.width * 0.04).clamp(1.0, 3.0);
-    let center_y = cell.y + (cell.height / 2.0);
-    let top = center_y - (marker_height / 2.0);
-    let bottom = center_y + (marker_height / 2.0);
+    let bar_width = 2.5;
+    let gap = 1.5;
+
     let volume_intensity = if max_qty > 0.0 {
         (qty / max_qty).clamp(0.0, 1.0) as f32
     } else {
         0.0
     };
     let imbalance_strength = alpha.clamp(0.0, 1.0);
-    let marker_alpha = 0.58 + (volume_intensity * 0.34) + (imbalance_strength * 0.08);
-    let marker_alpha = marker_alpha.clamp(0.58, 1.0);
-    let color = match side {
-        ImbalanceSide::Buy => palette.success.strong.color.scale_alpha(marker_alpha),
-        ImbalanceSide::Sell => palette.danger.strong.color.scale_alpha(marker_alpha),
+    let marker_alpha = 0.38 + (volume_intensity * 0.24) + (imbalance_strength * 0.38);
+    let marker_alpha = marker_alpha.clamp(0.38, 1.0);
+
+    let color = palette.warning.strong.color.scale_alpha(marker_alpha);
+
+    let (x, bar_w) = match side {
+        ImbalanceSide::Sell => (cell.x - bar_width - gap, bar_width),
+        ImbalanceSide::Buy => (cell.x + cell.width + gap, bar_width),
     };
 
-    let mut builder = canvas::path::Builder::new();
-    match side {
-        ImbalanceSide::Buy => {
-            let right = cell.x + cell.width - inset;
-            let left = right - marker_width;
-            builder.move_to(Point::new(right, top));
-            builder.line_to(Point::new(left, center_y));
-            builder.line_to(Point::new(right, bottom));
-        }
-        ImbalanceSide::Sell => {
-            let left = cell.x + inset;
-            let right = left + marker_width;
-            builder.move_to(Point::new(left, top));
-            builder.line_to(Point::new(right, center_y));
-            builder.line_to(Point::new(left, bottom));
-        }
-    }
-    builder.close();
-
-    frame.fill(&builder.build(), color);
+    frame.fill_rectangle(Point::new(x, cell.y), Size::new(bar_w, cell.height), color);
 }
 
 fn composite_color(foreground: Color, background: Color) -> Color {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -1038,6 +1038,21 @@ impl canvas::Program<Message> for KlineChart {
                         cell_width_unscaled,
                         footprint_cluster_min_width(*clusters),
                     );
+                    let draw_ctx = FootprintDrawCtx {
+                        price_to_y: &price_to_y,
+                        cell_width: chart.cell_width,
+                        cell_height: chart.cell_height,
+                        candle_width,
+                        palette,
+                        text_size,
+                        step: self.tick_size(),
+                        show_text,
+                        show_summary: self.visual_config.show_footprint_summary,
+                        show_table_candle: self.visual_config.show_footprint_table_candle,
+                        imbalance,
+                        cluster_kind: *clusters,
+                        spacing: content_spacing,
+                    };
 
                     if *clusters != ClusterKind::Table {
                         draw_all_npocs(
@@ -1070,23 +1085,11 @@ impl canvas::Program<Message> for KlineChart {
 
                             draw_clusters(
                                 frame,
-                                price_to_y,
+                                &draw_ctx,
                                 x_position,
-                                chart.cell_width,
-                                chart.cell_height,
-                                candle_width,
                                 cluster_scaling,
-                                palette,
-                                text_size,
-                                self.tick_size(),
-                                show_text,
-                                self.visual_config.show_footprint_summary,
-                                self.visual_config.show_footprint_table_candle,
-                                imbalance,
                                 kline,
                                 trades,
-                                *clusters,
-                                content_spacing,
                             );
                         },
                     );
@@ -1489,26 +1492,46 @@ fn effective_cluster_qty(
     }
 }
 
-fn draw_clusters(
-    frame: &mut canvas::Frame,
-    price_to_y: impl Fn(Price) -> f32,
-    x_position: f32,
+struct FootprintDrawCtx<'a, F>
+where
+    F: Fn(Price) -> f32,
+{
+    price_to_y: &'a F,
     cell_width: f32,
     cell_height: f32,
     candle_width: f32,
-    max_cluster_qty: f64,
-    palette: &Extended,
+    palette: &'a Extended,
     text_size: f32,
     step: PriceStep,
     show_text: bool,
     show_summary: bool,
     show_table_candle: bool,
     imbalance: Option<(usize, Option<usize>, bool)>,
-    kline: &Kline,
-    footprint: &KlineTrades,
     cluster_kind: ClusterKind,
     spacing: ContentGaps,
-) {
+}
+
+fn draw_clusters<F>(
+    frame: &mut canvas::Frame,
+    ctx: &FootprintDrawCtx<'_, F>,
+    x_position: f32,
+    max_cluster_qty: f64,
+    kline: &Kline,
+    footprint: &KlineTrades,
+) where
+    F: Fn(Price) -> f32,
+{
+    let price_to_y = ctx.price_to_y;
+    let cell_width = ctx.cell_width;
+    let cell_height = ctx.cell_height;
+    let candle_width = ctx.candle_width;
+    let palette = ctx.palette;
+    let text_size = ctx.text_size;
+    let step = ctx.step;
+    let show_text = ctx.show_text;
+    let imbalance = ctx.imbalance;
+    let cluster_kind = ctx.cluster_kind;
+    let spacing = ctx.spacing;
     let text_color = palette.background.weakest.text;
 
     let bar_width_factor: f32 = 0.9;
@@ -1623,7 +1646,7 @@ fn draw_clusters(
 
             draw_footprint_kline(
                 frame,
-                &price_to_y,
+                price_to_y,
                 area.candle_center_x,
                 candle_width,
                 kline,
@@ -1640,7 +1663,7 @@ fn draw_clusters(
                 kline,
                 palette,
                 spacing,
-                show_table_candle,
+                ctx.show_table_candle,
             );
             let table_width = area.width();
             let half_width = table_width / 2.0;
@@ -1857,7 +1880,7 @@ fn draw_clusters(
 
             draw_footprint_kline(
                 frame,
-                &price_to_y,
+                price_to_y,
                 area.candle_center_x,
                 candle_width,
                 kline,
@@ -1866,7 +1889,7 @@ fn draw_clusters(
         }
     }
 
-    if show_text && show_summary {
+    if show_text && ctx.show_summary {
         let Some(summary) = FootprintSummary::from_trades(footprint) else {
             return;
         };

--- a/src/modal/pane/indicators.rs
+++ b/src/modal/pane/indicators.rs
@@ -19,7 +19,13 @@ where
 {
     let content_allows_dragging = matches!(state.content, pane::Content::Kline { .. });
     let content_row = if let Some(market) = market_type {
-        content_row(pane, selected, market, content_allows_dragging)
+        content_row(
+            pane,
+            &state.content,
+            selected,
+            market,
+            content_allows_dragging,
+        )
     } else {
         column![].spacing(4).into()
     };
@@ -110,6 +116,7 @@ where
 
 fn content_row<'a, I>(
     pane: pane_grid::Pane,
+    content: &pane::Content,
     selected: &[I],
     market: exchange::adapter::MarketKind,
     allows_drag: bool,
@@ -119,15 +126,24 @@ where
 {
     let reorderable = allows_drag && selected.len() >= 2;
 
+    let selected: Vec<I> = selected
+        .iter()
+        .copied()
+        .filter(|indicator| indicator_allowed_for_content(content, (*indicator).into()))
+        .collect();
+
     let selected_list = if !selected.is_empty() {
-        Some(selected_list(pane, selected, reorderable))
+        Some(selected_list(pane, &selected, reorderable))
     } else {
         None
     };
 
     let available: Vec<I> = I::for_market(market)
         .iter()
-        .filter(|indicator| !selected.contains(indicator))
+        .filter(|indicator| {
+            !selected.contains(indicator)
+                && indicator_allowed_for_content(content, (**indicator).into())
+        })
         .cloned()
         .collect();
     let available_list = if !available.is_empty() {
@@ -151,4 +167,17 @@ where
     ]
     .spacing(4)
     .into()
+}
+
+fn indicator_allowed_for_content(content: &pane::Content, indicator: UiIndicator) -> bool {
+    !matches!(
+        (content, indicator),
+        (
+            pane::Content::Kline {
+                kind: data::chart::KlineChartKind::Candles,
+                ..
+            },
+            UiIndicator::Kline(data::chart::indicator::KlineIndicator::BarAnalysis)
+        )
+    )
 }

--- a/src/modal/pane/indicators.rs
+++ b/src/modal/pane/indicators.rs
@@ -129,7 +129,7 @@ where
     let selected: Vec<I> = selected
         .iter()
         .copied()
-        .filter(|indicator| indicator_allowed_for_content(content, (*indicator).into()))
+        .filter(|indicator| content.allows_indicator((*indicator).into()))
         .collect();
 
     let selected_list = if !selected.is_empty() {
@@ -141,8 +141,7 @@ where
     let available: Vec<I> = I::for_market(market)
         .iter()
         .filter(|indicator| {
-            !selected.contains(indicator)
-                && indicator_allowed_for_content(content, (**indicator).into())
+            !selected.contains(indicator) && content.allows_indicator((**indicator).into())
         })
         .cloned()
         .collect();
@@ -167,17 +166,4 @@ where
     ]
     .spacing(4)
     .into()
-}
-
-fn indicator_allowed_for_content(content: &pane::Content, indicator: UiIndicator) -> bool {
-    !matches!(
-        (content, indicator),
-        (
-            pane::Content::Kline {
-                kind: data::chart::KlineChartKind::Candles,
-                ..
-            },
-            UiIndicator::Kline(data::chart::indicator::KlineIndicator::BarAnalysis)
-        )
-    )
 }

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -726,15 +726,13 @@ pub fn kline_cfg_view<'a>(
                 ; spacing = 12, align_x = Alignment::Start
             ];
 
-            if *clusters != data::chart::kline::ClusterKind::Table {
-                content = content.push(
-                    column![
-                        text("Cluster scaling").size(crate::style::text_size::SECTION),
-                        scaling
-                    ]
-                    .spacing(8),
-                );
-            }
+            content = content.push(
+                column![
+                    text("Cluster scaling").size(crate::style::text_size::SECTION),
+                    scaling
+                ]
+                .spacing(8),
+            );
 
             content = content
                 .push(

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -663,23 +663,6 @@ pub fn kline_cfg_view<'a>(
                 TooltipPosition::Top,
             );
 
-            let table_candle_checkbox = tooltip(
-                checkbox(cfg.show_footprint_table_candle)
-                    .label("Show table candle")
-                    .on_toggle(move |value| {
-                        Message::VisualConfigChanged(
-                            pane,
-                            VisualConfig::Kline(data::chart::kline::Config {
-                                show_footprint_table_candle: value,
-                                ..cfg
-                            }),
-                            false,
-                        )
-                    }),
-                Some("Show a small candle next to footprint table clusters"),
-                TooltipPosition::Top,
-            );
-
             let scaling = {
                 let picklist = pick_list(
                     data::chart::kline::ClusterScaling::ALL,
@@ -751,15 +734,7 @@ pub fn kline_cfg_view<'a>(
                 ; spacing = 12, align_x = Alignment::Start
             ];
 
-            if *clusters == data::chart::kline::ClusterKind::Table {
-                content = content.push(
-                    column![
-                        text("Table display").size(crate::style::text_size::SECTION),
-                        table_candle_checkbox
-                    ]
-                    .spacing(8),
-                );
-            } else {
+            if *clusters != data::chart::kline::ClusterKind::Table {
                 content = content.push(
                     column![
                         text("Cluster scaling").size(crate::style::text_size::SECTION),

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -697,15 +697,7 @@ pub fn kline_cfg_view<'a>(
             let available_studies: Vec<_> = data::chart::kline::FootprintStudy::ALL
                 .iter()
                 .copied()
-                .filter(|study| {
-                    !matches!(
-                        (clusters, study),
-                        (
-                            data::chart::kline::ClusterKind::Table,
-                            data::chart::kline::FootprintStudy::NPoC { .. }
-                        )
-                    )
-                })
+                .filter(|study| clusters.allows_study(study))
                 .collect();
 
             let active_studies: Vec<_> = studies

--- a/src/modal/pane/settings.rs
+++ b/src/modal/pane/settings.rs
@@ -610,6 +610,7 @@ pub fn kline_cfg_view<'a>(
                         pane,
                         VisualConfig::Kline(data::chart::kline::Config {
                             data_labels_always_visible: value,
+                            ..cfg
                         }),
                         false,
                     )
@@ -645,6 +646,40 @@ pub fn kline_cfg_view<'a>(
                     Message::PaneEvent(pane, Event::ClusterKindSelected(new_cluster_kind))
                 });
 
+            let footprint_summary_checkbox = tooltip(
+                checkbox(cfg.show_footprint_summary)
+                    .label("Show footprint summary")
+                    .on_toggle(move |value| {
+                        Message::VisualConfigChanged(
+                            pane,
+                            VisualConfig::Kline(data::chart::kline::Config {
+                                show_footprint_summary: value,
+                                ..cfg
+                            }),
+                            false,
+                        )
+                    }),
+                Some("Show per-bar volume and delta below footprint candles"),
+                TooltipPosition::Top,
+            );
+
+            let table_candle_checkbox = tooltip(
+                checkbox(cfg.show_footprint_table_candle)
+                    .label("Show table candle")
+                    .on_toggle(move |value| {
+                        Message::VisualConfigChanged(
+                            pane,
+                            VisualConfig::Kline(data::chart::kline::Config {
+                                show_footprint_table_candle: value,
+                                ..cfg
+                            }),
+                            false,
+                        )
+                    }),
+                Some("Show a small candle next to footprint table clusters"),
+                TooltipPosition::Top,
+            );
+
             let scaling = {
                 let picklist = pick_list(
                     data::chart::kline::ClusterScaling::ALL,
@@ -676,24 +711,78 @@ pub fn kline_cfg_view<'a>(
                 }
             };
 
-            let study_cfg = study_config.view(studies, basis).map(move |msg| {
-                Message::PaneEvent(
-                    pane,
-                    Event::StudyConfigurator(study::StudyMessage::Footprint(msg)),
-                )
-            });
+            let available_studies: Vec<_> = data::chart::kline::FootprintStudy::ALL
+                .iter()
+                .copied()
+                .filter(|study| {
+                    !matches!(
+                        (clusters, study),
+                        (
+                            data::chart::kline::ClusterKind::Table,
+                            data::chart::kline::FootprintStudy::NPoC { .. }
+                        )
+                    )
+                })
+                .collect();
 
-            split_column![
+            let active_studies: Vec<_> = studies
+                .iter()
+                .copied()
+                .filter(|study| {
+                    available_studies
+                        .iter()
+                        .any(|available| available.is_same_type(study))
+                })
+                .collect();
+
+            let study_cfg = study_config
+                .view_available(&active_studies, basis, available_studies)
+                .map(move |msg| {
+                    Message::PaneEvent(
+                        pane,
+                        Event::StudyConfigurator(study::StudyMessage::Footprint(msg)),
+                    )
+                });
+
+            let mut content = split_column![
                 display_readout_section,
+                column![text("Footprint summary").size(crate::style::text_size::SECTION), footprint_summary_checkbox].spacing(8),
                 column![text("Cluster type").size(crate::style::text_size::SECTION), cluster_picklist].spacing(8),
-                column![text("Cluster scaling").size(crate::style::text_size::SECTION), scaling].spacing(8),
-                column![text("Studies").size(crate::style::text_size::SECTION), study_cfg].spacing(8),
-                row![
+                ; spacing = 12, align_x = Alignment::Start
+            ];
+
+            if *clusters == data::chart::kline::ClusterKind::Table {
+                content = content.push(
+                    column![
+                        text("Table display").size(crate::style::text_size::SECTION),
+                        table_candle_checkbox
+                    ]
+                    .spacing(8),
+                );
+            } else {
+                content = content.push(
+                    column![
+                        text("Cluster scaling").size(crate::style::text_size::SECTION),
+                        scaling
+                    ]
+                    .spacing(8),
+                );
+            }
+
+            content = content
+                .push(
+                    column![
+                        text("Studies").size(crate::style::text_size::SECTION),
+                        study_cfg
+                    ]
+                    .spacing(8),
+                )
+                .push(row![
                     space::horizontal(),
                     sync_all_button(pane, VisualConfig::Kline(cfg))
-                ],
-                ; spacing = 12, align_x = Alignment::Start
-            ]
+                ]);
+
+            content
         }
     };
 
@@ -1082,12 +1171,21 @@ pub mod study {
 
         pub fn view<'a>(
             &self,
-            active_studies: &'a [S],
+            active_studies: &[S],
             basis: data::chart::Basis,
+        ) -> Element<'a, Message<S>> {
+            self.view_available(active_studies, basis, S::all())
+        }
+
+        pub fn view_available<'a>(
+            &self,
+            active_studies: &[S],
+            basis: data::chart::Basis,
+            available_studies: Vec<S>,
         ) -> Element<'a, Message<S>> {
             let mut content = column![].spacing(4);
 
-            for available_study in S::all() {
+            for available_study in available_studies {
                 content =
                     content.push(self.create_study_row(available_study, active_studies, basis));
             }
@@ -1098,7 +1196,7 @@ pub mod study {
         fn create_study_row<'a>(
             &self,
             study: S,
-            active_studies: &'a [S],
+            active_studies: &[S],
             basis: data::chart::Basis,
         ) -> Element<'a, Message<S>> {
             let (is_selected, study_config) = {

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1959,7 +1959,10 @@ impl Content {
                 |indis| {
                     indis
                         .into_iter()
-                        .filter(|i| available.contains(i))
+                        .filter(|i| {
+                            available.contains(i)
+                                && kline_indicator_allowed(&determined_chart_kind, *i)
+                        })
                         .collect()
                 },
             )
@@ -2102,13 +2105,19 @@ impl Content {
             }
             (
                 Content::Kline {
-                    chart, indicators, ..
+                    chart,
+                    indicators,
+                    kind,
+                    ..
                 },
                 UiIndicator::Kline(ind),
             ) => {
                 let Some(chart) = chart else {
                     return;
                 };
+                if !kline_indicator_allowed(kind, ind) {
+                    return;
+                }
 
                 if indicators.contains(&ind) {
                     indicators.retain(|i| i != &ind);
@@ -2227,15 +2236,13 @@ impl Content {
                 *previous = studies;
             }
             (Content::Kline { chart, kind, .. }, data::chart::Study::Footprint(studies)) => {
-                chart
-                    .as_mut()
-                    .expect("kline chart not initialized")
-                    .set_studies(studies.clone());
+                let chart = chart.as_mut().expect("kline chart not initialized");
+                chart.set_studies(studies.clone());
                 if let data::chart::KlineChartKind::Footprint {
                     studies: k_studies, ..
                 } = kind
                 {
-                    *k_studies = studies;
+                    *k_studies = chart.studies().unwrap_or_default();
                 }
             }
             _ => {}
@@ -2274,6 +2281,16 @@ impl Content {
             Content::Starter => true,
         }
     }
+}
+
+fn kline_indicator_allowed(kind: &data::chart::KlineChartKind, indicator: KlineIndicator) -> bool {
+    !matches!(
+        (kind, indicator),
+        (
+            data::chart::KlineChartKind::Candles,
+            KlineIndicator::BarAnalysis
+        )
+    )
 }
 
 impl std::fmt::Display for Content {

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1960,8 +1960,7 @@ impl Content {
                     indis
                         .into_iter()
                         .filter(|i| {
-                            available.contains(i)
-                                && kline_indicator_allowed(&determined_chart_kind, *i)
+                            available.contains(i) && determined_chart_kind.allows_indicator(*i)
                         })
                         .collect()
                 },
@@ -2115,7 +2114,7 @@ impl Content {
                 let Some(chart) = chart else {
                     return;
                 };
-                if !kline_indicator_allowed(kind, ind) {
+                if !kind.allows_indicator(ind) {
                     return;
                 }
 
@@ -2281,16 +2280,18 @@ impl Content {
             Content::Starter => true,
         }
     }
-}
 
-fn kline_indicator_allowed(kind: &data::chart::KlineChartKind, indicator: KlineIndicator) -> bool {
-    !matches!(
-        (kind, indicator),
-        (
-            data::chart::KlineChartKind::Candles,
-            KlineIndicator::BarAnalysis
-        )
-    )
+    pub fn allows_indicator(&self, indicator: UiIndicator) -> bool {
+        match (self, indicator) {
+            (Content::Kline { kind, .. }, UiIndicator::Kline(indicator)) => {
+                kind.allows_indicator(indicator)
+            }
+            (Content::Heatmap { .. } | Content::ShaderHeatmap { .. }, UiIndicator::Heatmap(_)) => {
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 impl std::fmt::Display for Content {


### PR DESCRIPTION
  ## Summary

  Adds a focused footprint chart improvement with a new table-based cluster view, table-specific display controls, and a
  dedicated Bar Analysis indicator. Broader per-indicator configuration and custom color settings are intentionally left for a
  follow-up PR.

  ## Modified files

  ### `data/src/chart/indicator.rs`

  - Adds `KlineIndicator::BarAnalysis`.
  - Registers Bar Analysis for spot and perpetual markets.
  - Adds the display label `Bar Analysis`.

  ### `data/src/chart/kline.rs`

  - Adds `ClusterKind::Table`.
  - Includes `Table` in `ClusterKind::ALL`.
  - Updates cluster quantity handling so table mode uses bid/ask max quantity.
  - Adds `show_footprint_summary` to kline visual config.
  - Adds `show_footprint_table_candle` to kline visual config.
  - Defaults footprint summary to enabled.
  - Defaults table candle display to disabled.

  ### `src/chart/indicator/kline.rs`

  - Registers the new `bar_analysis` module.
  - Adds factory support for `KlineIndicator::BarAnalysis`.

  ### `src/chart/indicator/kline/bar_analysis.rs`

  - Adds the new Bar Analysis indicator.
  - Builds per-bar rows from `FootprintSummary`.
  - Displays ask, bid, volume, delta, and delta percentage.
  - Supports both time-based and tick-based kline data.
  - Rebuilds when klines, trades, tick size, or basis change.

  ### `src/chart/kline.rs`

  - Renders the new footprint `Table` cluster type.
  - Draws ask/sell quantity cells on the left and bid/buy quantity cells on the right.
  - Draws table grid borders.
  - Applies existing imbalance highlighting inside table cells.
  - Skips NPoC line rendering for table mode.
  - Adds optional candle rendering next to table clusters when `show_footprint_table_candle` is enabled.
  - Respects `show_footprint_summary` when drawing per-bar footprint summary labels.
  - Skips extra autoscale padding for summary labels when summary display is disabled.
  - Prevents `BarAnalysis` from rendering on candlestick charts.
  - Prevents `BarAnalysis` from being toggled on candlestick charts.
  - Sanitizes chart state so `Table + NPoC` is removed when loading or switching cluster type.
  - Filters NPoC out of studies when table mode is active.

  ### `src/modal/pane/indicators.rs`

  - Filters Bar Analysis out of the indicator modal for candlestick charts.
  - Keeps Bar Analysis available only when the current pane is a footprint chart.

  ### `src/modal/pane/settings.rs`

  - Adds a `Show footprint summary` checkbox.
  - Adds a `Show table candle` checkbox, visible only when cluster type is `Table`.
  - Hides `Cluster scaling` controls when cluster type is `Table`.
  - Filters `Naked Point of Control` out of available studies when cluster type is `Table`.
  - Adds support for rendering a filtered study list in the generic study configurator.

  ### `src/screen/dashboard/pane.rs`

  - Filters Bar Analysis out when initializing candlestick chart indicators.
  - Blocks Bar Analysis toggles on candlestick charts.
  - Keeps pane/chart kind state synchronized after unsupported footprint studies are removed.

  ## Deferred

  Intentionally left for later PRs:

  - Per-indicator persistent settings.
  - Custom indicator colors.
  - Custom footprint study colors.
  - Broader indicator settings UI refactors.

  ## Validation

  - `cargo fmt --check`
  - `cargo check`
  - `git diff --check`

<img width="1845" height="966" alt="image" src="https://github.com/user-attachments/assets/dc7fb561-0311-4167-8305-55ac37b55d29" />
