### PR TITLE
fix: popout/popup windows freeze when not focused

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use iced::{
         tooltip::Position as TooltipPosition,
     },
 };
-use std::{borrow::Cow, collections::HashMap, vec};
+use std::{borrow::Cow, collections::HashMap, time::Duration, vec};
 
 fn main() {
     logger::install_panic_hook();
@@ -765,7 +765,7 @@ impl Flowsurface {
             .market_subscriptions(&self.handles)
             .map(Message::MarketWsEvent);
 
-        let tick = iced::window::frames().map(Message::Tick);
+        let tick = iced::time::every(Duration::from_millis(16)).map(Message::Tick);
 
         let hotkeys = keyboard::listen().filter_map(|event| {
             let keyboard::Event::KeyPressed { key, .. } = event else {


### PR DESCRIPTION
## Problem

When a popup/popout window is focused, the main window stops updating visually, and vice versa. This makes the app feel broken when using multiple windows — whichever window isn't focused appears completely frozen.

## Root Cause

The app tick/update loop uses `iced::window::frames()`, which only emits frame events for the **currently focused** window. When focus moves to a popout, the main window stops receiving frame events and vice versa.

## Fix

Replace `iced::window::frames()` with `iced::time::every(Duration::from_millis(16))` (~60fps), which fires on a wall-clock interval independent of window focus. All windows now keep updating regardless of which one is focused.

```diff
-        let tick = iced::window::frames().map(Message::Tick);
+        let tick = iced::time::every(Duration::from_millis(16)).map(Message::Tick);
```

## Why 16ms

Matches roughly 60fps, consistent with the previous frame-driven behavior when a window was focused. The interval could be tuned further if needed (e.g. 33ms for ~30fps to reduce CPU usage).